### PR TITLE
fix(deps): bump pymdown-extensions to 11.0.1 to patch path traversal

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3414,15 +3414,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #34 (Moderate) on `pymdown-extensions`.

| Was | Now | Needs | Advisory |
|---|---|---|---|
| 10.21.3 | 11.0.1 | 11.0.0 | Path traversal in the `b64` extension — `<img src>` can read files outside `base_path` |

## Exposure assessment

Low, for two independent reasons:

- **Not enabled** — the vulnerable code path is the `pymdownx.b64` extension. This repo has no `mkdocs.yml` at all, so no pymdownx extension list exists to enable it.
- **Not in runtime installs** — the package arrives only via the optional `docs` extra (`mkdocs-material`, `mkdocstrings`). It is absent from a default `uv sync` / library install.

Bumped regardless so the advisory is cleared rather than dismissed.

## Major version note

The patch requires a major bump (10.x → 11.x), but neither consumer pins an upper bound — `mkdocs-material` requires `pymdown-extensions>=10.2`, `mkdocstrings` requires `>=6.3` — so 11.0.1 resolves cleanly with no knock-on changes (3-line `uv.lock` diff, only this entry).

## Verification

- `uv sync --extra docs` — clean, pymdownx 11.0.1
- `pymdownx.superfences` / `highlight` / `tabbed` render correctly via Markdown
- `mkdocs-material` + `mkdocstrings` import OK; `mkdocs --version` works
- `uv run pytest -m "not aws and not slow"` — **1729 passed**, 0 failures

Closes #34