### PR TITLE
feat(retrieval): make retrieval widths and context budgets configurable

### DIFF
--- a/config-template.yaml
+++ b/config-template.yaml
@@ -427,6 +427,14 @@ search:
     # When keyword extraction yields nothing, a query shorter than this falls
     # back to using the raw query as a low-level keyword (0 disables the gate).
     raw_query_fallback_max_len: 50
+    # Two separate retrieval widths, as in LightRAG: the entity/relationship
+    # vector queries are sized independently of the chunk stream. Both act as
+    # floors — a larger caller top_k wins.
+    kg_stream_top_k: 40
+    chunk_stream_top_k: 20
+    # Chunks allocated per matched entity/relationship when following text-unit
+    # lineage (slots decrease across matches so the last match still gets one).
+    related_chunk_number: 5
 
   # Global Search Configuration
   global_search:
@@ -461,6 +469,20 @@ search:
     # Drop graph-expanded entities appearing in more than this many text units
     # (too generic to be discriminative for local search).
     entity_frequency_threshold: 20
+    # Reserved fusion slots per section type, as max(multiplier * top_k, floor).
+    # Without reserved slots one type takes the whole flat top_k cut and crowds
+    # out the document chunks that carry the answer.
+    type_quota:
+      text_multiplier: 2.0
+      text_floor: 20
+      entity_multiplier: 1.0
+      entity_floor: 10
+      relationship_multiplier: 1.0
+      relationship_floor: 10
+      community_multiplier: 0.5
+      community_floor: 2
+      claim_multiplier: 0.5
+      claim_floor: 2
 
   # Drift Search Configuration
   drift_search:
@@ -492,6 +514,19 @@ search:
   token_manager:
     max_context_tokens: 200000
     token_count_cache_size: 1024
+    # A section truncated below this many tokens is dropped rather than emitted
+    # as an unusable fragment.
+    min_truncated_section_tokens: 64
+    # Relative shares of the context window per section type. Each type is packed
+    # against its own share only, so no type can crowd out another; shares are
+    # renormalized over the types actually present in a query's candidates.
+    type_budgets:
+      text: 0.50
+      entity: 0.20
+      relationship: 0.13
+      community: 0.10
+      claim: 0.07
+      general: 0.10
 
 # Memory Configuration
 memory:

--- a/tests/unit/test_config_template_knobs.py
+++ b/tests/unit/test_config_template_knobs.py
@@ -1,0 +1,72 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Guard that config-template.yaml stays in sync with the retrieval-tuning models.
+
+Every tuned retrieval number is a config knob rather than a module constant, which
+only helps operators if the template documents it AND the documented value parses
+into the model. A knob that drifts from its default (or fails to parse) is a silent
+trap: the template reads as authoritative but the running system uses something
+else. AWS-free — this only loads YAML and validates Pydantic models.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from unified_kg_rag.domain.models.config import SearchConfig
+
+pytestmark = pytest.mark.unit
+
+TEMPLATE = Path(__file__).resolve().parents[2] / "config-template.yaml"
+
+
+@pytest.fixture(scope="module")
+def template_search() -> SearchConfig:
+    raw: dict[str, Any] = yaml.safe_load(TEMPLATE.read_text())
+    return SearchConfig(**raw["search"])
+
+
+def test_template_search_block_parses(template_search: SearchConfig) -> None:
+    assert template_search.token_manager.type_budgets is not None
+    assert template_search.local_search.type_quota is not None
+
+
+def test_context_type_budgets_match_model_defaults(
+    template_search: SearchConfig,
+) -> None:
+    assert (
+        template_search.token_manager.type_budgets.model_dump()
+        == SearchConfig().token_manager.type_budgets.model_dump()
+    )
+
+
+def test_local_type_quota_matches_model_defaults(
+    template_search: SearchConfig,
+) -> None:
+    assert (
+        template_search.local_search.type_quota.model_dump()
+        == SearchConfig().local_search.type_quota.model_dump()
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["kg_stream_top_k", "chunk_stream_top_k", "related_chunk_number"],
+)
+def test_lightrag_width_knobs_match_model_defaults(
+    template_search: SearchConfig, field: str
+) -> None:
+    assert getattr(template_search.lightrag_search, field) == getattr(
+        SearchConfig().lightrag_search, field
+    )
+
+
+def test_truncation_floor_matches_model_default(template_search: SearchConfig) -> None:
+    assert (
+        template_search.token_manager.min_truncated_section_tokens
+        == SearchConfig().token_manager.min_truncated_section_tokens
+    )

--- a/tests/unit/test_evaluation_manager.py
+++ b/tests/unit/test_evaluation_manager.py
@@ -300,3 +300,19 @@ class TestLeanContextStrings:
         manager = _graph_aware_manager(config)
         out = manager.create_lean_context_strings([{"source": "s1", "score": 0.5}])
         assert "s1" in out[0]
+
+    def test_content_is_kept_for_vector_results(self, config: Config) -> None:
+        # A vector-retriever result carries its text in `content` and nothing else. It
+        # must NOT degrade to the id+score minimal-info fallback, or the top-scoring
+        # results reach RAGAS / Recall@k with no text to match against.
+        out = _graph_aware_manager(config).create_lean_context_strings(
+            [
+                {
+                    "content": "Miquette Giraudy is a keyboardist.",
+                    "source": "s1",
+                    "score": 0.9,
+                }
+            ]
+        )
+        assert "Miquette Giraudy" in out[0]
+        assert "s1" not in out[0]

--- a/tests/unit/test_hybrid_scorer.py
+++ b/tests/unit/test_hybrid_scorer.py
@@ -55,14 +55,46 @@ class TestNormalizeScores:
 
 
 class TestReciprocalRankFusion:
+    # Fusion blends a per-stream min-max-normalized NATIVE
+    # score into the RRF score, scaled to one RRF adjacent-rank step so it only
+    # orders items within an RRF-rank neighborhood (plain RRF made every item in a
+    # stream nearly indistinguishable, which let token_manager fill quota slots with
+    # the wrong item). So the expected score is now RRF + native_scale *
+    # native_norm, and the assertions below carry that term explicitly rather than
+    # asserting plain RRF. The scale is derived from `rrf_k`, not a fixed constant,
+    # so it stays correct for a reconfigured k — this helper mirrors that identity.
+    @staticmethod
+    def _expected(k: int, rrf: float, native_norm: float) -> float:
+        native_scale = 1.0 / (k + 1) - 1.0 / (k + 2)
+        return rrf + native_scale * native_norm
+
+    def test_native_blend_never_outweighs_one_rrf_rank_step(self) -> None:
+        # The contract the scale exists to hold: a maximally-favoured native score
+        # (1.0) may not lift a rank-2 item above a rank-1 item, at any configured k.
+        for k in (1, 10, 60, 500):
+            config = Config()
+            config.search.reranking.enabled = False
+            config.search.fusion.rrf_k = k
+            scorer = HybridScorer(config)
+            fused = scorer._reciprocal_rank_fusion(
+                {"src": [_r("first", 0.9, "1"), _r("second", 0.8, "2")]}
+            )
+            by_content = {r.content: r.score for r in fused}
+            assert by_content["first"] > by_content["second"], k
+
     def test_higher_rank_contributes_more(self) -> None:
         scorer = _scorer()
         k = scorer.fusion_config.rrf_k
         result_map = {"src": [_r("first", 0.9, "1"), _r("second", 0.8, "2")]}
         fused = scorer._reciprocal_rank_fusion(result_map)
         by_content = {r.content: r.score for r in fused}
-        assert by_content["first"] == pytest.approx(1.0 / (k + 1))
-        assert by_content["second"] == pytest.approx(1.0 / (k + 2))
+        # Two items in one stream min-max normalize to 1.0 (top) and 0.0 (bottom).
+        assert by_content["first"] == pytest.approx(
+            self._expected(k, 1.0 / (k + 1), 1.0)
+        )
+        assert by_content["second"] == pytest.approx(
+            self._expected(k, 1.0 / (k + 2), 0.0)
+        )
         assert by_content["first"] > by_content["second"]
 
     def test_cross_source_contributions_accumulate(self) -> None:
@@ -76,7 +108,8 @@ class TestReciprocalRankFusion:
         }
         fused = scorer._reciprocal_rank_fusion(result_map)
         assert len(fused) == 1
-        assert fused[0].score == pytest.approx(2.0 / (k + 1))
+        # A degenerate-range (single-item) stream normalizes to 0.5; RRF still accumulates.
+        assert fused[0].score == pytest.approx(self._expected(k, 2.0 / (k + 1), 0.5))
 
     def test_fused_object_is_a_copy(self) -> None:
         scorer = _scorer()
@@ -86,14 +119,15 @@ class TestReciprocalRankFusion:
 
     def test_default_weights_reproduce_plain_rrf(self) -> None:
         # Default fusion_weights are all 1.0 (and an unconfigured bucket defaults
-        # to 1.0 too), so RRF scoring is unchanged from plain RRF.
+        # to 1.0 too), so the RRF *term* is the unweighted 1/(k+rank) — the native
+        # blend above is the only other contribution.
         scorer = _scorer()
         assert all(w == 1.0 for w in scorer.fusion_config.fusion_weights.values())
         k = scorer.fusion_config.rrf_k
         fused = scorer._reciprocal_rank_fusion(
             {"unconfigured_bucket": [_r("only", 0.9, "1")]}
         )
-        assert fused[0].score == pytest.approx(1.0 / (k + 1))
+        assert fused[0].score == pytest.approx(self._expected(k, 1.0 / (k + 1), 0.5))
 
     def test_per_bucket_weight_scales_rrf_contribution(self) -> None:
         # A configured per-bucket weight now applies under RRF too (previously it
@@ -109,8 +143,10 @@ class TestReciprocalRankFusion:
         }
         fused = scorer._reciprocal_rank_fusion(result_map)
         by_content = {r.content: r.score for r in fused}
-        assert by_content["b"] == pytest.approx(3.0 / (k + 1))
-        assert by_content["p"] == pytest.approx(1.0 / (k + 1))
+        # Each bucket holds one item, so both normalize to native 0.5; the weight
+        # scaling applies to the RRF term, which is what this test is about.
+        assert by_content["b"] == pytest.approx(self._expected(k, 3.0 / (k + 1), 0.5))
+        assert by_content["p"] == pytest.approx(self._expected(k, 1.0 / (k + 1), 0.5))
         assert by_content["b"] > by_content["p"]
 
 
@@ -176,6 +212,57 @@ class TestFuseAndRerank:
         scorer.fuse_and_rerank_results({"a": [_r("x", 1.0, "1")]}, top_k=5)
         metrics = scorer.get_metrics()
         assert metrics["metrics"]["final_fused_count"] == 1
+
+
+class TestTypeQuota:
+    """A per-type quota is a cap as well as a floor.
+
+    Upstream LightRAG truncates the MERGED chunk pool to `chunk_top_k` before it
+    reaches the context, so a `text` quota of 20 must not grow to 40 just because
+    the two chunk streams together offered 40 candidates.
+    """
+
+    @staticmethod
+    def _typed(rtype: str, n: int, base: float) -> list[RetrievalResult]:
+        return [
+            RetrievalResult(
+                content=f"{rtype}-{i}",
+                score=base - i * 0.001,
+                source="s",
+                retriever_type=rtype,
+            )
+            for i in range(n)
+        ]
+
+    def test_over_quota_leftovers_do_not_backfill_their_own_type(self) -> None:
+        ranked = self._typed("text", 40, 0.9) + self._typed("entity", 60, 0.5)
+        out = HybridScorer._select_with_type_quota(
+            ranked, top_k=10, per_type_quota={"text": 20, "entity": 40}
+        )
+        counts: dict[str, int] = {}
+        for r in out:
+            counts[r.retriever_type] = counts.get(r.retriever_type, 0) + 1
+        assert counts == {"text": 20, "entity": 40}
+
+    def test_the_highest_scoring_items_of_each_type_are_the_ones_kept(self) -> None:
+        ranked = self._typed("text", 5, 0.9)
+        out = HybridScorer._select_with_type_quota(
+            ranked, top_k=2, per_type_quota={"text": 2}
+        )
+        assert [r.content for r in out] == ["text-0", "text-1"]
+
+    def test_types_without_a_quota_entry_still_backfill(self) -> None:
+        # A quota dict names the streams it bounds; anything else keeps the old
+        # behavior of filling the remaining budget by score.
+        ranked = self._typed("text", 2, 0.9) + self._typed("claim", 5, 0.5)
+        out = HybridScorer._select_with_type_quota(
+            ranked, top_k=6, per_type_quota={"text": 2}
+        )
+        counts: dict[str, int] = {}
+        for r in out:
+            counts[r.retriever_type] = counts.get(r.retriever_type, 0) + 1
+        assert counts["text"] == 2
+        assert counts["claim"] == 4  # budget max(top_k=6, quota sum=2) - 2 text
 
 
 class TestDiversityFiltering:

--- a/tests/unit/test_lightrag_search.py
+++ b/tests/unit/test_lightrag_search.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 import pytest
 
 import unified_kg_rag.adapters.search_strategies  # noqa: F401
+from unified_kg_rag.adapters.search_strategies.lightrag_search import (
+    _pick_by_weighted_polling,
+)
 from unified_kg_rag.domain.models import (
     Config,
     RetrievalResult,
@@ -45,6 +48,22 @@ class FakeRetriever:
         ]
 
 
+def _chunk_selector(config: Config | None = None):
+    """A strategy instance for the config-driven chunk-selection helpers.
+
+    ``_collect_linked_chunk_ids`` reads ``related_chunk_number`` off the config, so
+    it needs an instance; the retrievers are never touched by these helpers.
+    """
+    spec = get_strategy_spec(SearchStrategy.MIX)
+    return spec.strategy_class(
+        config=config or Config(),
+        retrievers={
+            RetrieverRole.DOCUMENT.value: FakeRetriever("document"),
+            RetrieverRole.GRAPH.value: FakeRetriever("graph"),
+        },
+    )
+
+
 def _make_strategy(config: Config):
     spec = get_strategy_spec(SearchStrategy.MIX)
     os_r, neptune_r = FakeRetriever("document"), FakeRetriever("graph")
@@ -57,7 +76,7 @@ def _make_strategy(config: Config):
     )
     # Stub the shared scorer to just flatten the source dict (avoid Bedrock).
     strategy.hybrid_scorer.fuse_and_rerank_results = (  # type: ignore[method-assign]
-        lambda results_dict, top_k, retrieval_multiplier=1, query=None: [
+        lambda results_dict, top_k, retrieval_multiplier=1, query=None, **_kw: [
             r for results in results_dict.values() for r in results
         ]
     )
@@ -120,8 +139,7 @@ async def test_mix_mode_blends_chunks(config: Config) -> None:
 
 
 def test_collect_linked_chunk_ids_ranks_by_citation_count() -> None:
-    spec = get_strategy_spec(SearchStrategy.MIX)
-    cls = spec.strategy_class
+    cls = _chunk_selector()
 
     def _hit(unit_ids: list[str]) -> RetrievalResult:
         return RetrievalResult(
@@ -143,8 +161,7 @@ def test_collect_linked_chunk_ids_ranks_by_citation_count() -> None:
 
 
 def test_collect_linked_chunk_ids_ignores_missing_lineage() -> None:
-    spec = get_strategy_spec(SearchStrategy.MIX)
-    cls = spec.strategy_class
+    cls = _chunk_selector()
     no_lineage = RetrievalResult(
         content="x", score=1.0, source="s", retriever_type="document", metadata={}
     )
@@ -182,7 +199,7 @@ async def test_mix_mode_fetches_linked_chunks_by_lineage(config: Config) -> None
         },
     )
     strategy.hybrid_scorer.fuse_and_rerank_results = (  # type: ignore[method-assign]
-        lambda results_dict, top_k, retrieval_multiplier=1, query=None: [
+        lambda results_dict, top_k, retrieval_multiplier=1, query=None, **_kw: [
             r for results in results_dict.values() for r in results
         ]
     )
@@ -224,8 +241,7 @@ async def test_long_empty_keyword_query_does_not_fall_back(config: Config) -> No
 
 
 def test_relationship_endpoint_ids_collects_both_endpoints() -> None:
-    spec = get_strategy_spec(SearchStrategy.HYBRID)
-    cls = spec.strategy_class
+    cls = _chunk_selector()
     rels = [
         RetrievalResult(
             content="r",
@@ -281,7 +297,7 @@ async def test_hl_only_query_seeds_graph_via_relationship_endpoints(
         },
     )
     strategy.hybrid_scorer.fuse_and_rerank_results = (  # type: ignore[method-assign]
-        lambda results_dict, top_k, retrieval_multiplier=1, query=None: [
+        lambda results_dict, top_k, retrieval_multiplier=1, query=None, **_kw: [
             r for results in results_dict.values() for r in results
         ]
     )
@@ -316,7 +332,7 @@ async def test_per_source_failure_degrades_to_empty_not_crash(config: Config) ->
         },
     )
     strategy.hybrid_scorer.fuse_and_rerank_results = (  # type: ignore[method-assign]
-        lambda results_dict, top_k, retrieval_multiplier=1, query=None: [
+        lambda results_dict, top_k, retrieval_multiplier=1, query=None, **_kw: [
             r for results in results_dict.values() for r in results
         ]
     )
@@ -325,3 +341,757 @@ async def test_per_source_failure_degrades_to_empty_not_crash(config: Config) ->
     )
     # Degrades gracefully: no results, no exception.
     assert result.results == []
+
+
+def test_collect_linked_chunk_ids_accepts_unwrapped_single_id() -> None:
+    # NeptuneRetriever._clean_property_map unwraps a single-element value_map list
+    # into a bare scalar, so a KG item whose lineage is exactly ONE chunk arrives
+    # with text_unit_ids as a str. The old isinstance(list) guard skipped those
+    # entirely, discarding the single-document bridge items multi-hop hinges on.
+    uuid = "8c1f2a70-1111-2222-3333-444455556666"
+    entity = RetrievalResult(
+        content="e",
+        score=1.0,
+        source="e1",
+        retriever_type="entity",
+        metadata={"text_unit_ids": uuid},
+    )
+    rel = RetrievalResult(
+        content="r",
+        score=1.0,
+        source="r1",
+        retriever_type="relationship",
+        metadata={"text_unit_ids": ["other-chunk"]},
+    )
+    ranked = _chunk_selector()._collect_linked_chunk_ids([entity], [rel], limit=10)
+    assert uuid in ranked
+    assert "other-chunk" in ranked
+
+
+class TestUpstreamTwoRetrievalWidths:
+    """Upstream LightRAG has TWO retrieval widths, not one.
+
+    ``QueryParam.top_k`` (DEFAULT_TOP_K = 40) sizes the ENTITY and RELATIONSHIP vector
+    queries; ``QueryParam.chunk_top_k`` (DEFAULT_CHUNK_TOP_K = 20) separately sizes the
+    chunk stream (lightrag/constants.py; ``search_top_k = query_param.chunk_top_k or
+    query_param.top_k`` in operate.py). Collapsing both onto the caller's single
+    ``top_k`` starved the KG streams: measured on musique50/n=50 at top_k=10, upstream
+    mix assembled a median 71 entities / 86 relations / 20 chunks per query against our
+    20 / 10 / 17, and scored token-F1 0.653 vs our 0.477 (McNemar p=0.021).
+    """
+
+    async def test_entity_and_relationship_queries_use_the_kg_width(
+        self, config: Config
+    ) -> None:
+        strategy, os_r, _ = _make_strategy(config)
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"], top_k=10)
+        )
+        # Only the unfiltered VECTOR queries; the id/endpoint-filtered fetches
+        # (linked chunks, the incident edges) are not sized by top_k.
+        by_prefix = {
+            call.index_prefixes[0]: call
+            for call in os_r.calls
+            if call.index_prefixes and not call.filters
+        }
+        entities = by_prefix[config.indexing.opensearch.entities_index_prefix]
+        relationships = by_prefix[config.indexing.opensearch.relationships_index_prefix]
+        # Upstream DEFAULT_TOP_K, not the caller's 10.
+        assert entities.top_k == 40
+        assert relationships.top_k == 40
+
+    async def test_chunk_query_uses_the_separate_chunk_width(
+        self, config: Config
+    ) -> None:
+        strategy, os_r, _ = _make_strategy(config)
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"], top_k=10)
+        )
+        text_units = [
+            call
+            for call in os_r.calls
+            if call.index_prefixes
+            and call.index_prefixes[0]
+            == config.indexing.opensearch.text_units_index_prefix
+            # the linked-chunk fetch is an id-filtered lexical lookup, not the
+            # naive vector query under test
+            and not call.filters
+        ]
+        assert text_units, "mix must run a naive vector chunk query"
+        assert all(call.top_k == 20 for call in text_units)
+
+    async def test_a_caller_top_k_above_the_default_still_widens(
+        self, config: Config
+    ) -> None:
+        # The upstream defaults are FLOORS, not caps: a lab sweep asking for top_k=60
+        # must not be narrowed back down to 40/20.
+        strategy, os_r, _ = _make_strategy(config)
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"], top_k=60)
+        )
+        assert all(
+            call.top_k == 60
+            for call in os_r.calls
+            if call.index_prefixes and not call.filters
+        )
+
+    async def test_mix_quota_matches_the_two_widths(self, config: Config) -> None:
+        strategy, _, _ = _make_strategy(config)
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, retrieval_multiplier=1, query=None, **kw):
+            captured.update(kw)
+            captured["top_k"] = top_k
+            return [r for results in results_dict.values() for r in results]
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"], top_k=10)
+        )
+        quota = captured["per_type_quota"]
+        # The quota -- not the vector-query width -- is what decides how much of each
+        # stream survives fusion into the context, so it has to carry the same contract.
+        assert quota["entity"] == 40
+        assert quota["relationship"] == 40
+        assert quota["text"] == 20
+
+    async def test_widths_track_the_configured_values(self, config: Config) -> None:
+        # The upstream defaults (40/20) are config, not constants: a deployment or a
+        # sweep that rebalances the two widths must move both the vector-query width
+        # and the fusion quota, and nothing may pin them back to the defaults.
+        config.search.lightrag_search.kg_stream_top_k = 25
+        config.search.lightrag_search.chunk_stream_top_k = 12
+        strategy, os_r, _ = _make_strategy(config)
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, retrieval_multiplier=1, query=None, **kw):
+            captured.update(kw)
+            return [r for results in results_dict.values() for r in results]
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"], top_k=5)
+        )
+        quota = captured["per_type_quota"]
+        assert quota["entity"] == 25
+        assert quota["relationship"] == 25
+        assert quota["text"] == 12
+        # And the vector queries themselves: KG streams at 25, chunk stream at 12.
+        widths = {
+            call.index_prefixes[0]: call.top_k
+            for call in os_r.calls
+            if call.index_prefixes and not call.filters
+        }
+        os_config = config.indexing.opensearch
+        assert widths[os_config.entities_index_prefix] == 25
+        assert widths[os_config.relationships_index_prefix] == 25
+        assert widths[os_config.text_units_index_prefix] == 12
+
+    async def test_non_mix_modes_keep_a_flat_width(self, config: Config) -> None:
+        # HYBRID has no chunk blend and no quota; only mix is realigned here, so the
+        # other modes must be untouched by this fix.
+        strategy, _, _ = _make_strategy(config)
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, retrieval_multiplier=1, query=None, **kw):
+            captured.update(kw)
+            return [r for results in results_dict.values() for r in results]
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(
+            _query(
+                SearchStrategy.HYBRID, ll_keywords=["a"], hl_keywords=["b"], top_k=10
+            )
+        )
+        assert captured.get("per_type_quota") is None
+
+    def test_linked_chunk_pool_is_bounded_by_the_chunk_width(self) -> None:
+        # The lineage pool is a CHUNK stream, so it follows chunk_top_k (20), not the
+        # caller's top_k (10) -- with 40 KG hits upstream's pool is much larger than a
+        # flat top_k before the final cut.
+        entities = [
+            RetrievalResult(
+                content="e",
+                score=1.0,
+                source=f"e{i}",
+                retriever_type="entity",
+                metadata={"text_unit_ids": [f"chunk-{i}"]},
+            )
+            for i in range(30)
+        ]
+        ranked = _chunk_selector()._collect_linked_chunk_ids(entities, [], limit=20)
+        assert len(ranked) == 20
+
+
+class TestUpstreamChunkSelection:
+    """KG-linked chunk selection must match upstream.
+
+    Upstream LightRAG picks the chunks behind its KG hits in two stages
+    (``operate.py`` ``_find_related_text_unit_from_entities`` /
+    ``_from_relations`` + ``utils.pick_by_weighted_polling``): a linear-decreasing
+    per-hit quota with a ``min_related_chunks=1`` floor, with the relationship
+    pass excluding chunks already taken by the entity pass, and a final
+    round-robin merge against the naive vector stream under one
+    ``seen_chunk_ids`` set (``_merge_chunks``).
+
+    The previous implementation ranked the pooled lineage by global citation
+    count and cut at ``chunk_top_k``, blind to the vector stream. Measured on
+    musique50/n=50 (m16 mix): 37.2% of the linked stream duplicated chunks the
+    vector query already returned, and gold-chain recall was 0.982 on
+    full-chain queries vs 0.477 on the rest.
+    """
+
+    @staticmethod
+    def _entity(idx: int, lineage: list[str]) -> RetrievalResult:
+        return RetrievalResult(
+            content="e",
+            score=1.0,
+            source=f"e{idx}",
+            retriever_type="entity",
+            metadata={"text_unit_ids": lineage},
+        )
+
+    def test_every_matched_hit_keeps_at_least_one_chunk(self) -> None:
+        # The defect this fix targets: a chunk cited by many entities used to take
+        # every slot, so the LAST entity -- which may hold the only chunk carrying
+        # a multi-hop question's second hop -- contributed nothing.
+        shared = [f"popular-{i}" for i in range(20)]
+        entities = [self._entity(i, list(shared)) for i in range(5)]
+        entities.append(self._entity(99, ["the-bridge-chunk"]))
+        selected = _chunk_selector()._collect_linked_chunk_ids(entities, [], limit=20)
+        assert "the-bridge-chunk" in selected
+
+    def test_vector_stream_chunks_are_excluded(self) -> None:
+        entities = [self._entity(0, ["dup-1", "dup-2", "fresh-1"])]
+        selected = _chunk_selector()._collect_linked_chunk_ids(
+            entities, [], limit=20, exclude={"dup-1", "dup-2"}
+        )
+        assert selected == ["fresh-1"]
+
+    def test_relationship_pass_excludes_entity_chunks(self) -> None:
+        entities = [self._entity(0, ["shared-1"])]
+        relationships = [
+            RetrievalResult(
+                content="r",
+                score=1.0,
+                source="r0",
+                retriever_type="relationship",
+                metadata={"text_unit_ids": ["shared-1", "rel-only"]},
+            )
+        ]
+        selected = _chunk_selector()._collect_linked_chunk_ids(
+            entities, relationships, limit=20
+        )
+        assert selected.count("shared-1") == 1
+        assert "rel-only" in selected
+
+    def test_pool_is_still_bounded_by_the_chunk_width(self) -> None:
+        entities = [
+            self._entity(i, [f"c-{i}-{j}" for j in range(5)]) for i in range(30)
+        ]
+        selected = _chunk_selector()._collect_linked_chunk_ids(entities, [], limit=20)
+        assert len(selected) == 20
+
+    def test_weighted_polling_matches_the_upstream_gradient(self) -> None:
+        # Upstream: expected[i] interpolates max_related_chunks -> min_related_chunks
+        # across the hits, so the first hit gets 5 and the last gets 1.
+        lineages = [[f"c{i}-{j}" for j in range(5)] for i in range(5)]
+        selected = _pick_by_weighted_polling(lineages, 5)
+        per_hit = [sum(1 for s in selected if s.startswith(f"c{i}-")) for i in range(5)]
+        assert per_hit == [5, 4, 3, 2, 1]
+
+    def test_weighted_polling_redistributes_unfilled_quota(self) -> None:
+        # The first hit can only supply 1 chunk; its remaining 4 slots must go to
+        # hits that still have unused chunks rather than being dropped.
+        lineages = [["only"], [f"b{j}" for j in range(9)]]
+        selected = _pick_by_weighted_polling(lineages, 5)
+        assert selected[0] == "only"
+        assert len(selected) == 1 + 5  # 1 own + 1 first-round + 4 redistributed
+
+    def test_single_hit_takes_the_full_related_chunk_number(self) -> None:
+        related = Config().search.lightrag_search.related_chunk_number
+        selected = _pick_by_weighted_polling([[f"c{j}" for j in range(9)]], related)
+        assert selected == [f"c{j}" for j in range(related)]
+
+
+class IncidentEdgeRetriever:
+    """Serves the entity index, then the incident-edge fetch by endpoint field.
+
+    ``edges`` maps ``(source_id, target_id) -> rank`` so a test can control both
+    which endpoint side finds an edge and the ``(rank, weight)`` ordering.
+    """
+
+    def __init__(self, config: Config, edges: dict[tuple[str, str], float]) -> None:
+        self.os_config = config.indexing.opensearch
+        self.edges = edges
+        self.calls: list[SearchQuery] = []
+
+    async def aretrieve(self, query: SearchQuery) -> list[RetrievalResult]:
+        self.calls.append(query)
+        prefix = query.index_prefixes[0] if query.index_prefixes else ""
+        if prefix == self.os_config.entities_index_prefix:
+            return [
+                RetrievalResult(
+                    content="e",
+                    score=1.0,
+                    source=eid,
+                    retriever_type="entity",
+                    metadata={"id": eid},
+                )
+                for eid in ("e1", "e2")
+            ]
+        if prefix != self.os_config.relationships_index_prefix:
+            return []
+        # The hl relationship vector query (no filters) returns one already-known edge.
+        if not query.filters:
+            return [
+                RetrievalResult(
+                    content="hl edge",
+                    score=1.0,
+                    source="rel-known",
+                    retriever_type="relationship",
+                    metadata={
+                        "id": "rel-known",
+                        "source_id": "e1",
+                        "target_id": "e-known",
+                    },
+                )
+            ]
+        # The incident fetch: one query per endpoint field.
+        field, wanted = next(iter(query.filters.items()))
+        hits = []
+        for (src, tgt), rank in self.edges.items():
+            endpoint = src if field == "source_id" else tgt
+            if endpoint in wanted:
+                hits.append(
+                    RetrievalResult(
+                        content=f"{src}->{tgt}",
+                        score=1.0,
+                        source=f"rel-{src}-{tgt}",
+                        retriever_type="relationship",
+                        metadata={
+                            "id": f"rel-{src}-{tgt}",
+                            "source_id": src,
+                            "target_id": tgt,
+                            "rank": rank,
+                            "weight": 1.0,
+                        },
+                    )
+                )
+        return hits
+
+
+def _incident_strategy(
+    config: Config, edges: dict[tuple[str, str], float], mode=SearchStrategy.MIX
+):
+    spec = get_strategy_spec(mode)
+    os_r = IncidentEdgeRetriever(config, edges)
+    strategy = spec.strategy_class(
+        config=config,
+        retrievers={
+            RetrieverRole.DOCUMENT.value: os_r,
+            RetrieverRole.GRAPH.value: FakeRetriever("graph"),
+        },
+    )
+    return strategy, os_r
+
+
+class TestIncidentRelationshipExpansion:
+    """Entity -> incident-edge cross-type expansion.
+
+    Upstream LightRAG's ``_find_most_related_edges_from_entities``
+    (``operate.py`` ~5204) pulls EVERY edge incident to the entity vector hits via
+    ``get_nodes_edges_batch``, dedups by ``tuple(sorted(e))``, orders by
+    ``(rank, weight)`` descending, and applies NO count cap — the per-type token
+    limit (``DEFAULT_MAX_RELATION_TOKENS`` = 8000) does the trimming. We had
+    only the mirror direction (relation -> endpoint entity), so its relationship
+    stream held a median 28 relations per query against upstream's 86 on
+    musique50/n=50: the candidates never existed to be truncated.
+    """
+
+    async def test_incident_edges_are_fetched_from_both_endpoint_sides(
+        self, config: Config
+    ) -> None:
+        # `_build_filter_clauses` ANDs every filter, so source_id OR target_id
+        # needs one query per side or every edge pointing INTO a matched entity is
+        # missed.
+        strategy, os_r = _incident_strategy(
+            config, {("e1", "x"): 3.0, ("y", "e2"): 2.0}
+        )
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, **kw):
+            captured["sources"] = results_dict
+            return []
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"])
+        )
+        fields = [
+            next(iter(call.filters))
+            for call in os_r.calls
+            if call.filters
+            and call.index_prefixes
+            == [config.indexing.opensearch.relationships_index_prefix]
+        ]
+        assert sorted(fields) == ["source_id", "target_id"]
+        incident = captured["sources"]["lightrag_incident_relationships"]
+        assert {r.source for r in incident} == {"rel-e1-x", "rel-y-e2"}
+
+    async def test_an_edge_between_two_matched_entities_is_carried_once(
+        self, config: Config
+    ) -> None:
+        # e1->e2 is reachable from BOTH endpoint queries; upstream's
+        # `tuple(sorted(e))` dedup keeps it once.
+        strategy, _ = _incident_strategy(config, {("e1", "e2"): 5.0})
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, **kw):
+            captured["sources"] = results_dict
+            return []
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"])
+        )
+        incident = captured["sources"]["lightrag_incident_relationships"]
+        assert [r.source for r in incident] == ["rel-e1-e2"]
+
+    async def test_edges_are_ordered_by_rank_then_weight(self, config: Config) -> None:
+        strategy, _ = _incident_strategy(
+            config, {("e1", "low"): 1.0, ("e1", "hub"): 9.0, ("e1", "mid"): 4.0}
+        )
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, **kw):
+            captured["sources"] = results_dict
+            return []
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"])
+        )
+        incident = captured["sources"]["lightrag_incident_relationships"]
+        assert [r.source for r in incident] == [
+            "rel-e1-hub",
+            "rel-e1-mid",
+            "rel-e1-low",
+        ]
+
+    async def test_edges_the_hl_query_already_returned_are_excluded(
+        self, config: Config
+    ) -> None:
+        # `rel-known` (e1 -> e-known) comes back from the hl relationship vector
+        # query; re-offering it from the incident side would spend the relationship
+        # quota twice on one edge.
+        strategy, _ = _incident_strategy(config, {("e1", "e-known"): 7.0})
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, **kw):
+            captured["sources"] = results_dict
+            return []
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"])
+        )
+        # The fake indexes the incident hit under a different doc id than the hl
+        # hit, so the exclusion has to bite on the endpoint pair, not the id.
+        incident = captured["sources"].get("lightrag_incident_relationships", [])
+        hl_pairs = {
+            (r.metadata["source_id"], r.metadata["target_id"])
+            for r in captured["sources"]["lightrag_relationships"]
+        }
+        assert not [
+            r
+            for r in incident
+            if (r.metadata["source_id"], r.metadata["target_id"]) in hl_pairs
+        ]
+
+    async def test_kg_quota_rises_to_the_expanded_candidate_count(
+        self, config: Config
+    ) -> None:
+        # Upstream applies no COUNT cap to the KG lists (only
+        # `_apply_token_truncation`), so the quota must be a floor that grows with
+        # the expansion — otherwise the per-type cap would clamp the newly found
+        # edges straight back to 40 and this fix would be a no-op.
+        edges = {("e1", f"x{i}"): float(i) for i in range(60)}
+        strategy, _ = _incident_strategy(config, edges)
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, retrieval_multiplier=1, query=None, **kw):
+            captured.update(kw)
+            return []
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"], top_k=10)
+        )
+        quota = captured["per_type_quota"]
+        # 60 incident edges + 1 hl edge, all retriever_type "relationship".
+        assert quota["relationship"] == 61
+        # Chunks keep their hard cap: upstream caps the MERGED chunk pool at
+        # chunk_top_k (the per-type cap).
+        assert quota["text"] == 20
+
+    async def test_no_entity_hits_means_no_incident_fetch(self, config: Config) -> None:
+        # An hl-only (thematic) query has no entity hits to expand from; the
+        # relation -> endpoint direction already covers that case.
+        strategy, os_r = _incident_strategy(config, {("e1", "x"): 1.0})
+        strategy.hybrid_scorer.fuse_and_rerank_results = (  # type: ignore[method-assign]
+            lambda results_dict, top_k, **kw: []
+        )
+        await strategy.asearch(_query(SearchStrategy.MIX, hl_keywords=["b"]))
+        assert not [
+            call
+            for call in os_r.calls
+            if call.filters
+            and call.index_prefixes
+            == [config.indexing.opensearch.relationships_index_prefix]
+        ]
+
+
+class EndpointEntityRetriever:
+    """Serves the hl relationship vector query, then the endpoint entity fetch.
+
+    ``rel_endpoints`` is the ordered list of ``(source_id, target_id)`` pairs the
+    hl relationship vector query returns; ``present`` is the set of entity ids the
+    entities index actually holds (so a missing node can be exercised).
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        rel_endpoints: list[tuple[str, str]],
+        present: set[str] | None = None,
+        ll_entity_ids: tuple[str, ...] = (),
+    ) -> None:
+        self.os_config = config.indexing.opensearch
+        self.rel_endpoints = rel_endpoints
+        self.present = present
+        self.ll_entity_ids = ll_entity_ids
+        self.calls: list[SearchQuery] = []
+
+    async def aretrieve(self, query: SearchQuery) -> list[RetrievalResult]:
+        self.calls.append(query)
+        prefix = query.index_prefixes[0] if query.index_prefixes else ""
+        if prefix == self.os_config.entities_index_prefix:
+            if not query.filters:
+                # the ll (low-level) entity vector query
+                return [
+                    RetrievalResult(
+                        content="ll entity",
+                        score=1.0,
+                        source=eid,
+                        retriever_type="entity",
+                        metadata={"id": eid},
+                    )
+                    for eid in self.ll_entity_ids
+                ]
+            wanted = list(query.filters["id"])
+            present = self.present if self.present is not None else set(wanted)
+            # OpenSearch returns terms-filter hits in index/score order, NOT in
+            # the order the ids were asked for -- reverse them to prove the
+            # strategy restores the endpoint order itself.
+            return [
+                RetrievalResult(
+                    content="endpoint entity",
+                    score=1.0,
+                    source=eid,
+                    retriever_type="entity",
+                    metadata={"id": eid},
+                )
+                for eid in reversed(wanted)
+                if eid in present
+            ]
+        if prefix != self.os_config.relationships_index_prefix:
+            return []
+        if query.filters:
+            return []  # the incident fetch: not under test here
+        return [
+            RetrievalResult(
+                content="hl edge",
+                score=1.0,
+                source=f"rel-{src}-{tgt}",
+                retriever_type="relationship",
+                metadata={"id": f"rel-{src}-{tgt}", "source_id": src, "target_id": tgt},
+            )
+            for src, tgt in self.rel_endpoints
+        ]
+
+
+def _endpoint_strategy(config: Config, os_r: EndpointEntityRetriever):
+    spec = get_strategy_spec(SearchStrategy.MIX)
+    return spec.strategy_class(
+        config=config,
+        retrievers={
+            RetrieverRole.DOCUMENT.value: os_r,
+            RetrieverRole.GRAPH.value: FakeRetriever("graph"),
+        },
+    )
+
+
+class TestRelationshipEndpointEntities:
+    """Relation endpoints are entity CANDIDATES.
+
+    Upstream's global side runs NO entity vector query — its entity context is
+    exactly the matched relationships' endpoints: ``_get_edge_data`` (operate.py
+    ~5419) passes its relationship vector hits to
+    ``_find_most_related_entities_from_relationships`` (~5478), which collects
+    ``src_id``/``tgt_id`` in first-seen order, fetches them with
+    ``get_nodes_batch``, and (in hybrid/mix) round-robin merges them with the ll
+    entity list in ``_merge_context``. We previously routed those same ids ONLY into
+    ``_expand_via_graph`` — a Neptune re-query returning the seeds' neighbourhood,
+    not the endpoints — so the endpoints never became context items and the entity
+    section sat at a median 48 per query against upstream's 71 on musique50/n=50.
+    """
+
+    @staticmethod
+    def _captured_sources(strategy) -> dict:
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, retrieval_multiplier=1, query=None, **kw):
+            captured["sources"] = results_dict
+            captured.update(kw)
+            return []
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        return captured
+
+    async def test_endpoints_become_their_own_entity_stream(
+        self, config: Config
+    ) -> None:
+        os_r = EndpointEntityRetriever(config, [("e1", "e2"), ("e3", "e4")])
+        strategy = _endpoint_strategy(config, os_r)
+        captured = self._captured_sources(strategy)
+        await strategy.asearch(_query(SearchStrategy.MIX, hl_keywords=["theme"]))
+
+        endpoints = captured["sources"]["lightrag_endpoint_entities"]
+        assert [r.source for r in endpoints] == ["e1", "e2", "e3", "e4"]
+        # They are entity-typed, so the `entity` quota floor picks them up.
+        assert {r.retriever_type for r in endpoints} == {"entity"}
+
+    async def test_endpoint_order_is_src_then_tgt_per_edge(
+        self, config: Config
+    ) -> None:
+        # Upstream appends src BEFORE tgt for each edge in relevance order, and the
+        # KG streams are not reranked -- stream position decides which endpoints
+        # survive fusion, so the order is load-bearing, not cosmetic.
+        os_r = EndpointEntityRetriever(config, [("a", "b"), ("c", "a"), ("d", "b")])
+        strategy = _endpoint_strategy(config, os_r)
+        captured = self._captured_sources(strategy)
+        await strategy.asearch(_query(SearchStrategy.MIX, hl_keywords=["theme"]))
+
+        endpoints = captured["sources"]["lightrag_endpoint_entities"]
+        assert [r.source for r in endpoints] == ["a", "b", "c", "d"]
+
+    async def test_entities_the_ll_query_already_returned_are_excluded(
+        self, config: Config
+    ) -> None:
+        # Upstream merges the two entity lists under one `seen_entities` set
+        # (`_merge_context`), so an endpoint that is also an ll vector hit must
+        # not spend the entity quota twice.
+        os_r = EndpointEntityRetriever(config, [("e1", "e2")], ll_entity_ids=("e1",))
+        strategy = _endpoint_strategy(config, os_r)
+        captured = self._captured_sources(strategy)
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["theme"])
+        )
+
+        fetched = [
+            call
+            for call in os_r.calls
+            if call.filters
+            and call.index_prefixes
+            == [config.indexing.opensearch.entities_index_prefix]
+        ]
+        assert [c.filters["id"] for c in fetched] == [["e2"]]
+        endpoints = captured["sources"]["lightrag_endpoint_entities"]
+        assert [r.source for r in endpoints] == ["e2"]
+
+    async def test_missing_nodes_are_skipped(self, config: Config) -> None:
+        # Upstream rebuilds `node_datas` from `get_nodes_batch` and skips ids the
+        # graph store has no node for, rather than emitting a placeholder.
+        os_r = EndpointEntityRetriever(
+            config, [("e1", "gone"), ("e3", "e4")], present={"e1", "e3", "e4"}
+        )
+        strategy = _endpoint_strategy(config, os_r)
+        captured = self._captured_sources(strategy)
+        await strategy.asearch(_query(SearchStrategy.MIX, hl_keywords=["theme"]))
+
+        endpoints = captured["sources"]["lightrag_endpoint_entities"]
+        assert [r.source for r in endpoints] == ["e1", "e3", "e4"]
+
+    async def test_entity_quota_rises_to_the_endpoint_count(
+        self, config: Config
+    ) -> None:
+        # Same contract as the incident expansion on the relationship side: upstream applies
+        # no COUNT cap to the entity list (only `_apply_token_truncation` against
+        # DEFAULT_MAX_ENTITY_TOKENS = 6000), so the quota floor has to grow with
+        # the expansion or the per-type cap clamps the endpoints straight back out.
+        pairs = [(f"s{i}", f"t{i}") for i in range(30)]
+        os_r = EndpointEntityRetriever(config, pairs, ll_entity_ids=("e1", "e2"))
+        strategy = _endpoint_strategy(config, os_r)
+        captured = self._captured_sources(strategy)
+        await strategy.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"], top_k=10)
+        )
+        # 60 endpoints + the 2 ll vector hits.
+        assert captured["per_type_quota"]["entity"] == 62
+
+    async def test_no_relationship_hits_means_no_endpoint_fetch(
+        self, config: Config
+    ) -> None:
+        # An ll-only query has no relationship hits; the entity -> incident-edge
+        # direction (incident edges) already covers that case.
+        os_r = EndpointEntityRetriever(config, [], ll_entity_ids=("e1",))
+        strategy = _endpoint_strategy(config, os_r)
+        strategy.hybrid_scorer.fuse_and_rerank_results = (  # type: ignore[method-assign]
+            lambda results_dict, top_k, **kw: []
+        )
+        await strategy.asearch(_query(SearchStrategy.MIX, ll_keywords=["a"]))
+        assert not [
+            call
+            for call in os_r.calls
+            if call.filters
+            and call.index_prefixes
+            == [config.indexing.opensearch.entities_index_prefix]
+        ]
+
+
+class TestEndpointSeedingIsPreserved:
+    """Emitting endpoints as entity candidates must not replace the graph seeding.
+
+    The endpoint ids serve two distinct purposes: they seed Neptune expansion (to
+    reach the endpoints' neighborhood) AND they are context items in their own
+    right (upstream ``_find_most_related_entities_from_relationships``). Adding
+    the second must keep the first.
+    """
+
+    async def test_endpoints_both_seed_neptune_and_become_candidates(
+        self, config: Config
+    ) -> None:
+        spec = get_strategy_spec(SearchStrategy.MIX)
+        os_r = EndpointEntityRetriever(config, [("e1", "e2")])
+        neptune_r = FakeRetriever("graph")
+        strategy = spec.strategy_class(
+            config=config,
+            retrievers={
+                RetrieverRole.DOCUMENT.value: os_r,
+                RetrieverRole.GRAPH.value: neptune_r,
+            },
+        )
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, **kw):
+            captured["sources"] = results_dict
+            return []
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(_query(SearchStrategy.MIX, hl_keywords=["theme"]))
+        # Still seeded into the Neptune expansion...
+        assert len(neptune_r.calls) == 1
+        assert set(neptune_r.calls[0].filters["id"]) == {"e1", "e2"}
+        # ...and also emitted as their own entity candidates.
+        assert captured["sources"]["lightrag_endpoint_entities"]

--- a/tests/unit/test_local_search_claims.py
+++ b/tests/unit/test_local_search_claims.py
@@ -60,7 +60,7 @@ def _make_strategy(config: Config):
     )
     # Stub the shared scorer to flatten the source dict (avoid Bedrock).
     strategy.hybrid_scorer.fuse_and_rerank_results = (  # type: ignore[method-assign]
-        lambda results_dict, top_k, retrieval_multiplier=1, query=None: [
+        lambda results_dict, top_k, retrieval_multiplier=1, query=None, **_kw: [
             r for results in results_dict.values() for r in results
         ]
     )

--- a/tests/unit/test_local_search_logic.py
+++ b/tests/unit/test_local_search_logic.py
@@ -158,6 +158,17 @@ def test_filter_entities_missing_metadata_treated_as_zero() -> None:
     assert len(kept) == 1
 
 
+def test_filter_entities_counts_unwrapped_single_id_as_one() -> None:
+    # NeptuneRetriever._clean_property_map unwraps a single-element value_map list
+    # into a bare scalar, so an entity appearing in exactly ONE text unit arrives
+    # with text_unit_ids as a str. len() on that counted 36 CHARACTERS and dropped
+    # the entity — precisely the single-document bridge nodes multi-hop needs.
+    uuid = "8c1f2a70-1111-2222-3333-444455556666"
+    nodes = [_result("single", metadata={"text_unit_ids": uuid})]
+    kept = LocalSearchStrategy._filter_entities(nodes, frequency_threshold=20)
+    assert [n.source for n in kept] == ["single"]
+
+
 # --------------------------------------------------------------------------- #
 # _find_candidate_entities
 # --------------------------------------------------------------------------- #
@@ -296,3 +307,67 @@ def test_record_search_metrics_populates_metrics() -> None:
         "entity_count": 3,
         "text_unit_count": 9,
     }
+
+
+# --------------------------------------------------------------------------- #
+# _rank_text_unit_ids / _restore_rank  (chunk candidates must be ranked)
+# --------------------------------------------------------------------------- #
+
+
+def test_rank_text_unit_ids_orders_by_entity_support() -> None:
+    # "shared" is referenced by two entities, "solo" by one -> shared ranks first.
+    nodes = [
+        _result("e1", score=0.4, metadata={"text_unit_ids": ["shared", "solo"]}),
+        _result("e2", score=0.9, metadata={"text_unit_ids": ["shared"]}),
+    ]
+    assert LocalSearchStrategy._rank_text_unit_ids(nodes)[0] == "shared"
+
+
+def test_rank_text_unit_ids_breaks_ties_by_best_entity_score() -> None:
+    nodes = [
+        _result("e1", score=0.2, metadata={"text_unit_ids": ["low"]}),
+        _result("e2", score=0.8, metadata={"text_unit_ids": ["high"]}),
+    ]
+    assert LocalSearchStrategy._rank_text_unit_ids(nodes) == ["high", "low"]
+
+
+def test_rank_text_unit_ids_handles_unwrapped_single_id() -> None:
+    # Neptune unwraps a single-element value_map list into a bare str.
+    uuid = "8c1f2a70-1111-2222-3333-444455556666"
+    nodes = [_result("e1", score=0.5, metadata={"text_unit_ids": uuid})]
+    assert LocalSearchStrategy._rank_text_unit_ids(nodes) == [uuid]
+
+
+def test_rank_text_unit_ids_dedups_across_entities() -> None:
+    nodes = [
+        _result("e1", score=0.5, metadata={"text_unit_ids": ["a", "b"]}),
+        _result("e2", score=0.5, metadata={"text_unit_ids": ["a"]}),
+    ]
+    assert sorted(LocalSearchStrategy._rank_text_unit_ids(nodes)) == ["a", "b"]
+
+
+def test_restore_rank_reorders_fetched_batch_to_ranked_order() -> None:
+    # The id-batch fetch returns index order; the graph-support ranking must win.
+    fetched = [_result("c3"), _result("c1"), _result("c2")]
+    out = LocalSearchStrategy._restore_rank(fetched, ["c1", "c2", "c3"])
+    assert [r.source for r in out] == ["c1", "c2", "c3"]
+
+
+def test_restore_rank_projects_descending_scores() -> None:
+    fetched = [_result("c2", score=0.0), _result("c1", score=0.0)]
+    out = LocalSearchStrategy._restore_rank(fetched, ["c1", "c2"])
+    # Scores must be strictly descending so downstream sorting is not arbitrary.
+    assert out[0].score > out[1].score
+    assert out[0].source == "c1"
+
+
+def test_restore_rank_puts_unranked_ids_last() -> None:
+    fetched = [_result("unknown"), _result("c1")]
+    out = LocalSearchStrategy._restore_rank(fetched, ["c1"])
+    assert [r.source for r in out] == ["c1", "unknown"]
+
+
+def test_restore_rank_empty_inputs_are_passthrough() -> None:
+    assert LocalSearchStrategy._restore_rank([], ["c1"]) == []
+    fetched = [_result("c1")]
+    assert LocalSearchStrategy._restore_rank(fetched, []) == fetched

--- a/tests/unit/test_local_search_sections.py
+++ b/tests/unit/test_local_search_sections.py
@@ -60,7 +60,7 @@ def _make_strategy(config: Config):
         },
     )
     strategy.hybrid_scorer.fuse_and_rerank_results = (  # type: ignore[method-assign]
-        lambda results_dict, top_k, retrieval_multiplier=1, query=None: [
+        lambda results_dict, top_k, retrieval_multiplier=1, query=None, **_kw: [
             r for results in results_dict.values() for r in results
         ]
     )
@@ -126,3 +126,36 @@ async def test_sections_fall_back_to_query_text_without_entity_focus(
     rel_calls = [q for q in os_r.calls if q.index_prefixes == [rel_prefix]]
     assert report_calls and report_calls[0].query == "raw text"
     assert rel_calls and rel_calls[0].query == "raw text"
+
+
+def test_per_type_quota_is_configured_shares_of_top_k(config: Config) -> None:
+    # The fusion quota is config, not constants: MS local's proportional context
+    # assembly is expressed as per-type multipliers of top_k with a floor, so a
+    # deployment that rebalances the shares must move the quota.
+    strategy, _, _ = _make_strategy(config)
+    quota_config = config.search.local_search.type_quota
+
+    quota = strategy._per_type_quota(top_k=40)
+    assert quota["text"] == int(quota_config.text_multiplier * 40)
+    assert quota["entity"] == int(quota_config.entity_multiplier * 40)
+    assert quota["relationship"] == int(quota_config.relationship_multiplier * 40)
+    assert quota["community"] == int(quota_config.community_multiplier * 40)
+    assert quota["claim"] == int(quota_config.claim_multiplier * 40)
+
+    quota_config.community_multiplier = 2.0
+    assert strategy._per_type_quota(top_k=40)["community"] == 80
+
+
+def test_per_type_quota_floors_hold_at_a_tiny_top_k(config: Config) -> None:
+    # At top_k=1 the multipliers alone would reserve 0-2 slots, which starves the
+    # KG sections the multi-hop bridge items live in; the floors are what keep each
+    # section represented.
+    strategy, _, _ = _make_strategy(config)
+    quota_config = config.search.local_search.type_quota
+
+    quota = strategy._per_type_quota(top_k=1)
+    assert quota["text"] == quota_config.text_floor
+    assert quota["entity"] == quota_config.entity_floor
+    assert quota["relationship"] == quota_config.relationship_floor
+    assert quota["community"] == quota_config.community_floor
+    assert quota["claim"] == quota_config.claim_floor

--- a/tests/unit/test_opensearch_retriever_logic.py
+++ b/tests/unit/test_opensearch_retriever_logic.py
@@ -394,3 +394,45 @@ def test_extract_content_translated_suppresses_raw_text(retriever, config) -> No
 def test_extract_content_uses_raw_text_when_no_translation(retriever) -> None:
     content = retriever._extract_content({"text": "raw body"})
     assert "raw body" in content
+
+
+# Relationship hits must name their endpoints, mirroring
+# upstream LightRAG's `{"entity1", "entity2", "description"}` relations_context.
+# Without the names a relationship line is unresolvable text, and widening the
+# relationship stream to upstream's top_k=40 then multiplies noise instead of
+# signal (measured: it made mix token-F1 fall, not rise).
+
+
+def test_extract_content_names_relationship_endpoints(retriever) -> None:
+    content = retriever._extract_content(
+        {
+            "source_name": "erik erikson",
+            "target_name": "joan erikson",
+            "type": "spouse",
+            "description": "Marriage relationship",
+        }
+    )
+    assert "Relationship: erik erikson -[spouse]-> joan erikson" in content
+    assert "Description: Marriage relationship" in content
+
+
+def test_extract_content_relationship_without_a_type_still_names_endpoints(
+    retriever,
+) -> None:
+    content = retriever._extract_content(
+        {"source_name": "a", "target_name": "b", "description": "d"}
+    )
+    assert "Relationship: a -> b" in content
+
+
+def test_extract_content_relationship_with_one_missing_endpoint(retriever) -> None:
+    # A half-populated edge is still more useful named than anonymous.
+    content = retriever._extract_content({"source_name": "a", "description": "d"})
+    assert "Relationship: a -> unknown" in content
+
+
+def test_extract_content_non_relationship_hit_gets_no_relationship_line(
+    retriever,
+) -> None:
+    content = retriever._extract_content({"name": "Alice", "description": "researcher"})
+    assert "Relationship:" not in content

--- a/tests/unit/test_rag_chain_parsing.py
+++ b/tests/unit/test_rag_chain_parsing.py
@@ -226,9 +226,15 @@ def test_format_output_step_builds_rag_output() -> None:
     assert out.metadata["total_results"] == 1
     # carried-over metadata from the SearchResult is merged in.
     assert out.metadata["extra"] == 1
-    # sources project only source/score/metadata.
+    # sources project content/source/score/metadata. `content` is required: a vector
+    # result carries its text there and nowhere else, so dropping it left the
+    # highest-scoring sources with no text for RAGAS / recall scoring to match on.
     assert out.sources[0]["source"] == "doc-1"
-    assert set(out.sources[0].keys()) == {"source", "score", "metadata"}
+    assert out.sources[0]["content"] == "c1"
+    assert set(out.sources[0].keys()) == {"content", "source", "score", "metadata"}
+    # retriever_type / chunk_id stay out — the projection is still explicit, not a
+    # full model_dump.
+    assert "retriever_type" not in out.sources[0]
 
 
 def test_format_search_output_step_returns_serializable_dict() -> None:

--- a/tests/unit/test_token_manager.py
+++ b/tests/unit/test_token_manager.py
@@ -12,14 +12,17 @@ word-count stub so assertions are exact and AWS is never touched.
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from unified_kg_rag.adapters.retrieval import token_manager as tm_module
 from unified_kg_rag.adapters.retrieval.token_manager import (
+    ContextSection,
     OptimizedContext,
     SectionType,
     TokenManager,
 )
 from unified_kg_rag.domain.models import Config, RetrievalResult
+from unified_kg_rag.domain.models.config import ContextTypeBudgetConfig
 
 pytestmark = pytest.mark.unit
 
@@ -114,6 +117,42 @@ class TestPriorityOrdering:
         assert out.sections_included == 1
         assert out.sections[0].section_type == SectionType.TEXT
 
+    def test_a_window_too_small_for_any_share_still_yields_one_section(
+        self, mocker
+    ) -> None:
+        # Shares divide across present types but the truncation floor does not, so a
+        # small window with several present types can drive EVERY type's share below
+        # the floor. Returning nothing there would hand the generator an empty
+        # context while a whole section still fit; the highest-priority section is
+        # seated instead.
+        mgr = _make_manager(mocker)
+        results = [
+            _r("g g g g g", 0.5, "general", "gen"),
+            _r("t t t t t", 0.5, "text", "txt"),
+        ]
+        out = mgr.optimize_context(
+            results, query="q", max_tokens=6, max_context_tokens_buffer=0
+        )
+        assert out.sections_included == 1
+        assert out.total_tokens <= 5
+        # TEXT (1.3) outranks GENERAL (0.8) at equal base score.
+        assert out.sections[0].section_type == SectionType.TEXT
+
+    def test_last_resort_section_is_truncated_when_nothing_fits_whole(
+        self, mocker
+    ) -> None:
+        mgr = _make_manager(mocker)
+        floor = mgr.config.min_truncated_section_tokens
+        out = mgr.optimize_context(
+            [_r(" ".join(["t"] * 500), 0.9, "text", "t0")],
+            query="q",
+            max_tokens=floor + 1,
+            max_context_tokens_buffer=0,
+        )
+        assert out.sections_included == 1
+        assert out.sections[0].metadata["truncated"] is True
+        assert out.total_tokens <= floor
+
     def test_unknown_retriever_type_falls_back_to_general(self, mocker) -> None:
         mgr = _make_manager(mocker)
         # An out-of-enum retriever_type must degrade to GENERAL, not raise
@@ -162,6 +201,226 @@ class TestPriorityOrdering:
         # score 0.0 is falsy -> base_score becomes 0.5; ENTITY multiplier 1.2.
         section = mgr._create_context_section(result, index=0)
         assert section.priority == pytest.approx(0.5 * 1.2)
+
+
+class TestPerTypeBudgetIsAHardCap:
+    """TYPE_BUDGET_PROP must CAP each type, not floor it.
+
+    The previous implementation packed each type to its sub-budget and then ran a
+    second pass that pooled every unused token and offered it to the leftovers of
+    ANY type by raw priority. That made the proportions advisory: whichever type
+    had the most/highest-scoring leftovers absorbed the whole remainder (measured
+    on musique50/n=50: community reports took 0.68 of the window against a 0.10
+    prop; with ranked chunk scores TEXT took 0.84 and evicted every community
+    report). Neither upstream pools — MS GraphRAG's mixed_context packs community
+    / local / text against three independent strict budgets and LightRAG
+    truncates each type separately.
+    """
+
+    def test_one_type_cannot_exceed_its_share_when_another_type_has_candidates(
+        self, mocker
+    ) -> None:
+        mgr = _make_manager(mocker)
+        # available = 1000 - 1(query) - 0(buffer) = 1000 tokens.
+        # TEXT prop 0.50 / COMMUNITY prop 0.10 -> renormalized over the two present
+        # types: TEXT 5/6 (833), COMMUNITY 1/6 (166).
+        # 40 text sections of 100 tokens each want 4000 tokens; they must not eat
+        # the community share even though TEXT has the higher priority multiplier.
+        text_results = [
+            _r(" ".join(["t"] * 100), 0.9, "text", f"t{i}") for i in range(40)
+        ]
+        community_results = [
+            _r(" ".join(["c"] * 100), 0.4, "community", f"c{i}") for i in range(5)
+        ]
+        out = mgr.optimize_context(
+            text_results + community_results,
+            query="q",
+            max_tokens=1001,
+            max_context_tokens_buffer=0,
+        )
+        by_type: dict[SectionType, int] = {}
+        for section in out.sections:
+            by_type[section.section_type] = (
+                by_type.get(section.section_type, 0) + section.token_count
+            )
+        assert (
+            by_type.get(SectionType.COMMUNITY, 0) > 0
+        ), "a lower-priority type with candidates must keep its share"
+        assert by_type[SectionType.TEXT] <= 850
+        assert out.total_tokens <= 1000
+
+    def test_absent_type_share_is_renormalized_not_wasted(self, mocker) -> None:
+        # With ONLY text candidates, the props renormalize to 1.0 for TEXT, so the
+        # whole window is usable — a hard cap must not mean a wasted window.
+        # Renormalization over PRESENT types is static (it does not look at how many
+        # candidates a type has), which is what keeps it from degenerating into the
+        # leftover-pooling this fix removes.
+        mgr = _make_manager(mocker)
+        results = [_r(" ".join(["t"] * 100), 0.9, "text", f"t{i}") for i in range(20)]
+        out = mgr.optimize_context(
+            results, query="q", max_tokens=1001, max_context_tokens_buffer=0
+        )
+        assert out.total_tokens == 1000
+
+    def test_unused_share_of_a_sparse_type_is_left_unused(self, mocker) -> None:
+        # TEXT is sparse (2 candidates); COMMUNITY has plenty. The rest of TEXT's
+        # share must be LEFT UNUSED, not handed to community reports. Re-offering
+        # the remainder to whichever type still has candidates was measured to
+        # reproduce the original defect verbatim (community kept 0.66 of the window
+        # because it was the only type with candidates left), which is why this is a
+        # single pass.
+        mgr = _make_manager(mocker)
+        results = [_r(" ".join(["t"] * 50), 0.9, "text", f"t{i}") for i in range(2)] + [
+            _r(" ".join(["c"] * 50), 0.4, "community", f"c{i}") for i in range(40)
+        ]
+        out = mgr.optimize_context(
+            results, query="q", max_tokens=1001, max_context_tokens_buffer=0
+        )
+        by_type: dict[SectionType, int] = {}
+        for section in out.sections:
+            by_type[section.section_type] = (
+                by_type.get(section.section_type, 0) + section.token_count
+            )
+        # Renormalized over {TEXT 0.50, COMMUNITY 0.10} -> TEXT 833, COMMUNITY 166.
+        assert by_type[SectionType.TEXT] == 100  # only 2 candidates exist
+        assert by_type[SectionType.COMMUNITY] <= 200
+        assert out.total_tokens < 400  # the rest of TEXT's share stays unused
+
+    def test_general_only_candidates_still_get_a_budget(self, mocker) -> None:
+        # Global search emits ONLY GENERAL sections, so renormalizing over present
+        # types must not produce a zero budget and an empty context for that whole
+        # strategy.
+        mgr = _make_manager(mocker)
+        results = [_r(" ".join(["g"] * 50), 0.9, "general", f"g{i}") for i in range(10)]
+        out = mgr.optimize_context(
+            results, query="q", max_tokens=1001, max_context_tokens_buffer=0
+        )
+        assert out.sections_included == 10
+        assert out.total_tokens == 500
+
+    def test_general_mixed_with_another_type_gets_a_nonzero_budget(
+        self, mocker
+    ) -> None:
+        # Regression: GENERAL used to carry a hardcoded 0.0 share, so as soon as it
+        # co-occurred with any other type its renormalized budget was 0 and the
+        # section was dropped. That silently discarded global search's map-reduce
+        # synthesis and drift's primer answer whenever a run also carried community
+        # or text sections.
+        mgr = _make_manager(mocker)
+        budgets = mgr._type_budgets([SectionType.GENERAL, SectionType.COMMUNITY], 600)
+        assert budgets[SectionType.GENERAL] > 0
+        assert budgets[SectionType.COMMUNITY] > 0
+
+        results = [_r(" ".join(["g"] * 20), 0.9, "general", "g0")] + [
+            _r(" ".join(["c"] * 20), 0.9, "community", "c0")
+        ]
+        out = mgr.optimize_context(
+            results, query="q", max_tokens=1001, max_context_tokens_buffer=0
+        )
+        assert {s.section_type for s in out.sections} == {
+            SectionType.GENERAL,
+            SectionType.COMMUNITY,
+        }
+
+    def test_type_budgets_renormalize_over_present_types(self, mocker) -> None:
+        mgr = _make_manager(mocker)
+        budgets = mgr._type_budgets([SectionType.TEXT, SectionType.COMMUNITY], 600)
+        # 0.50 : 0.10 -> 5/6 : 1/6 of 600.
+        assert budgets[SectionType.TEXT] == 500
+        assert budgets[SectionType.COMMUNITY] == 100
+
+    def test_type_budgets_track_reconfigured_shares(self, mocker) -> None:
+        # The shares are config, not constants: a deployment that rebalances them
+        # must move the budgets.
+        mgr = _make_manager(mocker)
+        mgr.config.type_budgets.text = 0.10
+        mgr.config.type_budgets.community = 0.30
+        budgets = mgr._type_budgets([SectionType.TEXT, SectionType.COMMUNITY], 600)
+        assert budgets[SectionType.TEXT] == 150
+        assert budgets[SectionType.COMMUNITY] == 450
+
+    def test_type_budgets_equal_split_when_present_shares_are_all_zero(
+        self, mocker
+    ) -> None:
+        # A config may zero out the share of a type that still shows up in a
+        # result set; splitting evenly beats emitting an empty context.
+        mgr = _make_manager(mocker)
+        mgr.config.type_budgets.general = 0.0
+        mgr.config.type_budgets.claim = 0.0
+        budgets = mgr._type_budgets([SectionType.GENERAL, SectionType.CLAIM], 600)
+        assert budgets[SectionType.GENERAL] == 300
+        assert budgets[SectionType.CLAIM] == 300
+
+    def test_oversized_section_is_truncated_to_fit_its_share(self, mocker) -> None:
+        # A single retrieved item can exceed its whole type share (a community report
+        # routinely exceeds a 10% cap). Dropping the type outright cost 5 gold
+        # contexts and shrank the window 29k -> 8.8k chars, so the first overflowing
+        # section is truncated to fit instead.
+        mgr = _make_manager(mocker)
+        results = [_r(" ".join(["t"] * 5000), 0.9, "text", "t0")]
+        out = mgr.optimize_context(
+            results, query="q", max_tokens=1001, max_context_tokens_buffer=0
+        )
+        assert out.sections_included == 1
+        section = out.sections[0]
+        assert section.metadata["truncated"] is True
+        assert section.content.endswith("…")
+        assert section.token_count <= 1000
+        assert out.total_tokens <= 1000
+
+    def test_truncation_floor_drops_a_section_too_small_to_be_evidence(
+        self, mocker
+    ) -> None:
+        # A share of a handful of tokens carries no usable evidence; emit nothing
+        # rather than a meaningless fragment.
+        mgr = _make_manager(mocker)
+        section = mgr._truncate_to_tokens(
+            ContextSection(
+                content="a b c d e f",
+                token_count=6,
+                priority=1.0,
+                section_type=SectionType.TEXT,
+                source_id="s",
+            ),
+            max_tokens=mgr.config.min_truncated_section_tokens - 1,
+        )
+        assert section is None
+
+    def test_truncation_preserves_a_prefix_on_a_word_boundary(self, mocker) -> None:
+        original = ContextSection(
+            content=" ".join(f"w{i}" for i in range(1000)),
+            token_count=1000,
+            priority=1.0,
+            section_type=SectionType.COMMUNITY,
+            source_id="c0",
+        )
+        mgr = _make_manager(mocker)
+        section = mgr._truncate_to_tokens(original, max_tokens=100)
+        assert section is not None
+        assert section.content.startswith("w0 w1 w2")
+        assert "  " not in section.content
+        assert len(section.content) < len(original.content)
+        # The original is not mutated (sections are shared across the pipeline).
+        assert original.token_count == 1000
+        assert not original.metadata
+
+    def test_a_type_whose_first_candidate_overflows_is_still_represented(
+        self, mocker
+    ) -> None:
+        # The regression this guards: COMMUNITY's share was 10% of the window and
+        # every single report was larger than that, so the whole section vanished
+        # (COMM share 0.676 -> 0.0).
+        mgr = _make_manager(mocker)
+        results = [
+            _r(" ".join(["t"] * 100), 0.9, "text", f"t{i}") for i in range(20)
+        ] + [_r(" ".join(["c"] * 900), 0.4, "community", "c0")]
+        out = mgr.optimize_context(
+            results, query="q", max_tokens=1001, max_context_tokens_buffer=0
+        )
+        types = {s.section_type for s in out.sections}
+        assert SectionType.COMMUNITY in types
+        assert SectionType.TEXT in types
+        assert out.total_tokens <= 1000
 
 
 class TestQualityScore:
@@ -217,7 +476,48 @@ class TestBuildContextString:
         ]
         out = mgr.optimize_context(results, query="q", max_tokens=10000)
         rendered = TokenManager.build_context_string(out)
-        assert "Source Type: TEXT" in rendered
-        assert "Source ID: src-a" in rendered
-        assert "\n\n---\n\n" in rendered  # section separator
+        # The rendering groups by type: sections are now
+        # GROUPED under labeled type headers (mirroring LightRAG's
+        # Entities/Relationships/Chunks blocks and MS's sectioned tables) instead of
+        # a flat per-item "Source Type / Source ID / Priority" dump. The meaningless
+        # Priority float was dropped; ids are rendered as a citable "[id]" prefix.
+        assert "##### Document Chunks" in rendered
+        assert "##### Knowledge Graph — Entities" in rendered
+        assert "[src-a]" in rendered
         assert "first chunk text" in rendered
+
+
+class TestContextTypeBudgetConfig:
+    def test_all_zero_shares_are_rejected_at_config_load(self) -> None:
+        # The renormalization fallback in _type_budgets only covers the types
+        # PRESENT in one result set; a config with every share at zero expresses
+        # "never emit a context", which is never what an operator means.
+        with pytest.raises(ValidationError):
+            ContextTypeBudgetConfig(
+                text=0.0,
+                entity=0.0,
+                relationship=0.0,
+                community=0.0,
+                claim=0.0,
+                general=0.0,
+            )
+
+    def test_negative_shares_are_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContextTypeBudgetConfig(text=-0.1)
+
+    def test_shares_need_not_sum_to_one(self) -> None:
+        # Shares are renormalized over present types, so they are ratios, not a
+        # partition — over- or under-summing is legitimate.
+        budget = ContextTypeBudgetConfig(text=2.0, entity=1.0)
+        assert budget.text == pytest.approx(2.0)
+
+    def test_every_section_type_maps_to_a_budget_field(self) -> None:
+        # A new SectionType with no share field would silently fall back to 0.0 and
+        # be dropped whenever it co-occurred with another type — the exact defect
+        # GENERAL's hardcoded 0.0 caused.
+        for section_type in SectionType:
+            assert section_type in TokenManager._BUDGET_FIELDS
+            assert hasattr(
+                ContextTypeBudgetConfig(), TokenManager._BUDGET_FIELDS[section_type]
+            )

--- a/unified_kg_rag/adapters/retrieval/hybrid_scorer.py
+++ b/unified_kg_rag/adapters/retrieval/hybrid_scorer.py
@@ -65,6 +65,8 @@ class HybridScorer(MetricsMixin):
         top_k: int,
         retrieval_multiplier: int = 1,
         query: str | None = None,
+        per_type_quota: dict[str, int] | None = None,
+        rerank_only_types: set[str] | None = None,
     ) -> list[RetrievalResult]:
         start_time = time.time()
         method = self.fusion_config.method
@@ -95,15 +97,56 @@ class HybridScorer(MetricsMixin):
         combined_results = fusion_func(fusion_input)
 
         if self.fusion_config.diversity_lambda < 1.0:
+            # Diversity filtering cuts to top_k*multiplier — which, with top_k=10,
+            # pre-starves the fused set to 10 BEFORE rerank/quota, so a per-type quota
+            # (sum ~50) has nothing left to protect and a KG item at native rank ~10 is
+            # already gone. When a quota is set, keep at least the quota budget so
+            # diversity de-dups WITHIN that budget instead of collapsing it.
+            div_top_k = top_k
+            if per_type_quota:
+                div_top_k = max(top_k, sum(per_type_quota.values()))
             combined_results = self._apply_diversity_filtering(
-                combined_results, top_k=top_k, retrieval_multiplier=retrieval_multiplier
+                combined_results,
+                top_k=div_top_k,
+                retrieval_multiplier=retrieval_multiplier,
             )
 
         if self.rerank_model is not None and query is not None:
-            combined_results = self._apply_bedrock_reranking(combined_results, query)
+            if rerank_only_types is None:
+                combined_results = self._apply_bedrock_reranking(
+                    combined_results, query
+                )
+            else:
+                # Rerank ONLY the given types (e.g. {"text"}), leaving KG streams
+                # (entity/relationship/community) on their native degree/cosine order.
+                # Content-vs-query reranking buries multi-hop BRIDGE entities/relations
+                # whose description lacks the question's surface terms, and upstream
+                # LightRAG reranks chunks only.
+                to_rerank = [
+                    r for r in combined_results if r.retriever_type in rerank_only_types
+                ]
+                kept = [
+                    r
+                    for r in combined_results
+                    if r.retriever_type not in rerank_only_types
+                ]
+                if to_rerank:
+                    to_rerank = self._apply_bedrock_reranking(to_rerank, query)
+                combined_results = kept + to_rerank
 
         combined_results.sort(key=lambda x: x.score or 0.0, reverse=True)
-        final_results = combined_results[:top_k]
+        # A single cross-type [:top_k] cut lets one type (usually entities, with many
+        # near-tie RRF scores) crowd out text chunks — which is where LightRAG/GraphRAG
+        # multi-hop answers actually live. When per_type_quota is given, guarantee each
+        # retriever_type its own slots (mirrors LightRAG's separate 40-entity /
+        # 20-chunk streams) before back-filling the remainder by score. No quota ->
+        # the original flat behavior (other strategies unaffected).
+        if per_type_quota:
+            final_results = self._select_with_type_quota(
+                combined_results, top_k, per_type_quota
+            )
+        else:
+            final_results = combined_results[:top_k]
 
         processing_time = time.time() - start_time
         self._record_timing("processing_time", processing_time)
@@ -118,6 +161,62 @@ class HybridScorer(MetricsMixin):
         )
 
         return final_results
+
+    @staticmethod
+    def _select_with_type_quota(
+        ranked: list[RetrievalResult],
+        top_k: int,
+        per_type_quota: dict[str, int],
+    ) -> list[RetrievalResult]:
+        """Pick up to quota[type] of each retriever_type (in score order), then
+        back-fill any remaining top_k budget from types that carry NO quota.
+
+        Guarantees text chunks (and each other type) their reserved slots instead of
+        losing every slot to a single dominant type under flat RRF ties.
+
+        A quota is a CAP as well as a floor. The back-fill
+        used to re-offer over-quota leftovers to any type, so `text`'s 20-slot
+        chunk quota silently became 40 (the two chunk streams' full width) — while
+        upstream LightRAG truncates the MERGED chunk pool to `chunk_top_k` (20)
+        before it ever reaches the context (`utils.process_chunks_unified` steps
+        1+3, called from `operate._build_context_str`). The surplus chunks consumed
+        window that upstream spends on the KG sections. Types with no quota entry still
+        back-fill, so non-mix strategies (which pass no quota at all) are unchanged.
+
+        ``top_k`` bounds only that back-fill of unquotaed types; the quotaed types
+        are bounded by their own entries. A quota is therefore an explicit, larger
+        request than ``top_k`` — the caller's ``top_k`` cannot shrink slots the
+        strategy deliberately reserved — and the effective ceiling is logged when
+        the two disagree so an unexpectedly wide result set is traceable.
+        """
+        selected: list[RetrievalResult] = []
+        used_per_type: dict[str, int] = {}
+        leftovers: list[RetrievalResult] = []
+        for r in ranked:  # already score-sorted desc
+            rtype = r.retriever_type
+            quota = per_type_quota.get(rtype, 0)
+            if used_per_type.get(rtype, 0) < quota:
+                selected.append(r)
+                used_per_type[rtype] = used_per_type.get(rtype, 0) + 1
+            elif rtype not in per_type_quota:
+                leftovers.append(r)
+        # back-fill remaining budget by score (leftovers are already in score order)
+        quota_total = sum(per_type_quota.values())
+        budget = max(top_k, quota_total)
+        if quota_total > top_k:
+            logger.debug(
+                "Per-type quota (%s slots across %s types) exceeds top_k=%s; "
+                "the quota governs the result width",
+                quota_total,
+                len(per_type_quota),
+                top_k,
+            )
+        for r in leftovers:
+            if len(selected) >= budget:
+                break
+            selected.append(r)
+        selected.sort(key=lambda x: x.score or 0.0, reverse=True)
+        return selected
 
     @staticmethod
     def _normalize_scores(results: list[RetrievalResult]) -> list[RetrievalResult]:
@@ -163,12 +262,22 @@ class HybridScorer(MetricsMixin):
         scores: dict[str, float] = defaultdict(float)
         objects: dict[str, RetrievalResult] = {}
 
+        # Plain RRF overwrites each item's score with a flat
+        # weight/(k+rank) (~0.0164 at rank1 vs 0.0143 at rank10) — so WITHIN a stream
+        # the gold item is indistinguishable from noise, and downstream token_manager
+        # (priority = score*multiplier) fills quota slots with the wrong item (the
+        # "Medavoy retrieved but dropped from context" bug). Upstream LightRAG keeps
+        # the native order (entities by cosine, relations by degree). We preserve that
+        # by BLENDING a per-stream min-max-normalized native score into the RRF score:
+        # cross-stream fusion still comes from RRF rank; within-stream discrimination
+        # is restored by the native component (scaled small so it breaks ties/orders
+        # within a rank neighborhood without dominating the cross-stream RRF signal).
+        native_norm: dict[str, float] = {}
+        for results in result_map.values():
+            for r in self._normalize_scores(results):
+                native_norm[self._get_result_key(r)] = r.score or 0.0
+
         for name, results in result_map.items():
-            # Weighted RRF: a per-bucket weight scales that source's rank
-            # contribution. Buckets without a configured weight default to 1.0,
-            # so an empty fusion_weights map reproduces plain RRF exactly — but a
-            # configured weight is now honored under RRF too (previously it was
-            # silently ignored unless FusionMethod.WEIGHTED was selected).
             weight = weights.get(name, 1.0)
             for rank, result in enumerate(results, 1):
                 key = self._get_result_key(result)
@@ -176,9 +285,17 @@ class HybridScorer(MetricsMixin):
                 if key not in objects:
                     objects[key] = result.model_copy()
 
+        # The native component must order items WITHIN an RRF-rank tie without
+        # flipping genuine cross-stream rank gaps, so scale it to the granularity of
+        # one RRF rank step. Adjacent-rank steps are 1/(k+r) - 1/(k+r+1), largest at
+        # r=1; derive the scale from that identity rather than fixing a constant, so
+        # it tracks a reconfigured `rrf_k` (at the default k=60 this is ~2.7e-4).
+        # Native scores are min-max normalized to [0, 1], so the blended component
+        # can never exceed a single rank step.
+        native_scale = 1.0 / (k + 1) - 1.0 / (k + 2)
         for key, score in scores.items():
             if key in objects:
-                objects[key].score = score
+                objects[key].score = score + native_scale * native_norm.get(key, 0.0)
 
         return list(objects.values())
 

--- a/unified_kg_rag/adapters/retrieval/token_manager.py
+++ b/unified_kg_rag/adapters/retrieval/token_manager.py
@@ -189,23 +189,165 @@ class TokenManager(MetricsMixin):
             metadata=result.metadata or {},
         )
 
-    @staticmethod
+    # Both upstreams (MS GraphRAG `mixed_context`, LightRAG
+    # `_apply_token_truncation`) split the context window into PER-TYPE
+    # sub-budgets and pack each type independently, so text chunks (which hold the
+    # multi-hop answer) are guaranteed representation and can't be crowded out by a
+    # flat greedy fill of near-tie RRF scores. The shares themselves are
+    # configurable (`search.token_manager.type_budgets`); this maps the enum onto
+    # that model's field names so a new SectionType is a compile-time concern
+    # rather than a silent zero share.
+    _BUDGET_FIELDS: ClassVar[dict[SectionType, str]] = {
+        SectionType.TEXT: "text",
+        SectionType.ENTITY: "entity",
+        SectionType.RELATIONSHIP: "relationship",
+        SectionType.CLAIM: "claim",
+        SectionType.COMMUNITY: "community",
+        SectionType.GENERAL: "general",
+    }
+
+    def _type_budget_shares(
+        self, present: list[SectionType]
+    ) -> dict[SectionType, float]:
+        configured = self.config.type_budgets
+        return {
+            t: float(getattr(configured, self._BUDGET_FIELDS[t], 0.0)) for t in present
+        }
+
+    def _type_budgets(
+        self, present: list[SectionType], token_budget: int
+    ) -> dict[SectionType, int]:
+        # Renormalize the shares over the types actually present, so an absent type
+        # does not silently shrink the window. If every present type is configured
+        # to 0.0, fall back to equal shares rather than emitting an empty context
+        # for the whole query — a share of zero should express "deprioritize", not
+        # "discard the only evidence there is".
+        shares = self._type_budget_shares(present)
+        total = sum(shares.values())
+        if total <= 0.0:
+            shares = dict.fromkeys(present, 1.0)
+            total = float(len(present)) or 1.0
+        return {t: int(token_budget * s / total) for t, s in shares.items()}
+
     def _select_optimal_sections(
-        sections: list[ContextSection], token_budget: int
+        self, sections: list[ContextSection], token_budget: int
     ) -> list[ContextSection]:
-        sorted_sections = sorted(sections, key=lambda s: s.priority, reverse=True)
-        selected_sections = []
-        used_tokens = 0
+        # The per-type budget is a HARD CAP, not a floor.
+        #
+        # This used to pack each type to its sub-budget and then run a second pass
+        # that pooled ALL unused budget and offered it to the leftover sections of
+        # ANY type by raw priority. Because PRIORITY_MULTIPLIERS favors TEXT (1.3)
+        # and every leftover competed in one global pool, whichever type happened to
+        # have the most/highest-scoring leftovers absorbed the entire remainder. That
+        # made the configured shares advisory rather than binding: one type could
+        # take most of the window against a 0.10 share, and once chunk candidates
+        # carried real descending rank scores TEXT evicted the community and entity
+        # sections almost entirely.
+        #
+        # Neither upstream pools: MS GraphRAG's mixed_context builds the community /
+        # local / text sections against three INDEPENDENT strict token budgets
+        # (community_prop, 1 - community_prop - text_unit_prop, text_unit_prop);
+        # LightRAG truncates entities / relations / chunks against separate per-type
+        # limits. Mirror that: each type is packed only against its own cap, and no
+        # type can ever cross into another's share by out-scoring it.
+        by_type: dict[SectionType, list[ContextSection]] = {}
+        for s in sections:
+            if s.token_count > 0:
+                by_type.setdefault(s.section_type, []).append(s)
+        if not by_type:
+            return []
+        for lst in by_type.values():
+            lst.sort(key=lambda s: s.priority, reverse=True)
 
-        for section in sorted_sections:
-            if section.token_count == 0:
-                continue
+        # ONE pass, no leftover re-offering. A type that cannot fill its share
+        # (e.g. only 8 chunk candidates survive local search's entity ceiling)
+        # leaves the remainder UNUSED — exactly as MS GraphRAG leaves an unfilled
+        # text_unit_prop share unused rather than handing it to community reports.
+        # Re-offering the remainder to whichever type still has candidates was
+        # measured to reproduce the original defect verbatim: community reports
+        # kept 0.66 of the window because they were the only type with candidates
+        # left. Renormalization over PRESENT types (in _type_budgets) is the only
+        # redistribution, and it is static — it cannot depend on how many
+        # candidates a type happens to have.
+        budgets = self._type_budgets(list(by_type), token_budget)
+        selected: list[ContextSection] = []
+        for stype, lst in by_type.items():
+            cap = budgets[stype]
+            sub_used = 0
+            for section in lst:
+                room = cap - sub_used
+                if room <= 0:
+                    break
+                if section.token_count <= room:
+                    selected.append(section)
+                    sub_used += section.token_count
+                    continue
+                # The section overflows the remaining share. Upstream's rows are
+                # table rows, so it simply stops; ours are whole retrieved items,
+                # and a single community report routinely exceeds a 10% share —
+                # dropping the type outright cost 5 gold contexts and shrank the
+                # window from 29k to 8.8k chars. Truncate the FIRST overflowing
+                # section to fit instead, so every type with candidates is
+                # represented, then stop this type (the budget is now spent).
+                head = self._truncate_to_tokens(section, room)
+                if head is not None:
+                    selected.append(head)
+                break
 
-            if used_tokens + section.token_count <= token_budget:
-                selected_sections.append(section)
-                used_tokens += section.token_count
+        if selected:
+            return selected
 
-        return selected_sections
+        # Last resort: every present type's renormalized share came out below the
+        # truncation floor, so no type could seat even one item — yet the window
+        # itself has room for a whole section. That happens when the window is
+        # small relative to the number of present types (shares divide, the floor
+        # does not). Returning nothing here would hand the generator an empty
+        # context while evidence that fits was on the table, so seat the single
+        # highest-priority section instead. This cannot reintroduce the
+        # crowding-out defect above: it only runs when the per-type pass selected
+        # nothing at all, and it seats exactly one section.
+        ranked = sorted(
+            (s for lst in by_type.values() for s in lst),
+            key=lambda s: s.priority,
+            reverse=True,
+        )
+        for section in ranked:
+            if section.token_count <= token_budget:
+                return [section]
+        head = self._truncate_to_tokens(ranked[0], token_budget)
+        return [head] if head is not None else []
+
+    def _truncate_to_tokens(
+        self, section: ContextSection, max_tokens: int
+    ) -> ContextSection | None:
+        """Cut a section's content down to roughly ``max_tokens``, or None if the
+        budget is too small to carry anything meaningful.
+
+        Cuts on a whitespace boundary using the section's own measured
+        tokens-per-character ratio: this runs inside the packing loop, so a real
+        token count per candidate prefix would mean an extra Bedrock count_tokens
+        round trip per section. The ratio is exact enough for a budget cap, and the
+        result is deliberately conservative (floor + an explicit ellipsis marker).
+        """
+        if (
+            max_tokens < self.config.min_truncated_section_tokens
+            or section.token_count <= 0
+        ):
+            return None
+        chars_per_token = len(section.content) / section.token_count
+        keep_chars = int(max_tokens * chars_per_token)
+        if keep_chars <= 0:
+            return None
+        head = section.content[:keep_chars].rsplit(" ", 1)[0].rstrip()
+        if not head:
+            return None
+        return section.model_copy(
+            update={
+                "content": f"{head} …",
+                "token_count": max_tokens,
+                "metadata": {**section.metadata, "truncated": True},
+            }
+        )
 
     @staticmethod
     def _calculate_quality_score(
@@ -241,15 +383,41 @@ class TokenManager(MetricsMixin):
 
     @staticmethod
     def build_context_string(optimized_context: OptimizedContext) -> str:
+        # Group sections by type under labeled
+        # headers (mirrors LightRAG's Entities/Relationships/Chunks blocks and MS's
+        # sectioned tables) instead of a flat per-item "Source Type/Priority" dump.
+        # The Priority float was meaningless prompt noise; dropped. Text chunks carry
+        # a citable [id]; the answer prompt can reference them.
         if not optimized_context.sections:
             return EMPTY_CONTEXT_PLACEHOLDER
 
-        context_parts = []
-        for section in optimized_context.sections:
-            header = (
-                f"## Source Type: {section.section_type.value.upper()} "
-                f"(Source ID: {section.source_id}, Priority: {section.priority:.2f})"
-            )
-            context_parts.append(f"{header}\n{section.content}")
+        order = [
+            SectionType.TEXT,
+            SectionType.ENTITY,
+            SectionType.RELATIONSHIP,
+            SectionType.CLAIM,
+            SectionType.COMMUNITY,
+            SectionType.GENERAL,
+        ]
+        labels = {
+            SectionType.TEXT: "Document Chunks",
+            SectionType.ENTITY: "Knowledge Graph — Entities",
+            SectionType.RELATIONSHIP: "Knowledge Graph — Relationships",
+            SectionType.CLAIM: "Claims",
+            SectionType.COMMUNITY: "Community Reports",
+            SectionType.GENERAL: "Other Context",
+        }
+        grouped: dict[SectionType, list[ContextSection]] = {}
+        for s in optimized_context.sections:
+            grouped.setdefault(s.section_type, []).append(s)
 
-        return "\n\n---\n\n".join(context_parts).strip()
+        blocks: list[str] = []
+        for stype in order:
+            items = grouped.get(stype)
+            if not items:
+                continue
+            lines = [f"##### {labels[stype]}"]
+            for s in items:
+                lines.append(f"[{s.source_id}] {s.content}")
+            blocks.append("\n".join(lines))
+        return "\n\n".join(blocks).strip()

--- a/unified_kg_rag/adapters/retrievers/opensearch_retriever.py
+++ b/unified_kg_rag/adapters/retrievers/opensearch_retriever.py
@@ -553,6 +553,24 @@ class OpenSearchRetriever(BaseGraphRAGRetriever):
         if translated_text := source.get(translated_key):
             content_parts.append(translated_text)
 
+        # A relationship hit MUST name its endpoints.
+        # Upstream LightRAG renders every relation as
+        # `{"entity1": src, "entity2": tgt, "description": ...}` (operate.py
+        # `relations_context`), so the reader can always tell what is related to
+        # what. We indexed `source_name`/`target_name` (opensearch_indexer.py:371)
+        # but never rendered them, emitting bare fragments like
+        # "Description: Date of birth relationship" — text naming neither endpoint,
+        # which the reader cannot resolve. That is why widening the relationship
+        # stream made scores WORSE instead of better: it multiplied unusable lines.
+        src_name = source.get("source_name")
+        tgt_name = source.get("target_name")
+        if src_name or tgt_name:
+            rel_type = source.get("type")
+            arrow = f" -[{rel_type}]-> " if rel_type else " -> "
+            content_parts.append(
+                f"Relationship: {src_name or 'unknown'}{arrow}{tgt_name or 'unknown'}"
+            )
+
         if description := source.get("description"):
             content_parts.append(f"Description: {description}")
 

--- a/unified_kg_rag/adapters/search_strategies/lightrag_search.py
+++ b/unified_kg_rag/adapters/search_strategies/lightrag_search.py
@@ -9,10 +9,12 @@ unified-kg-rag-on-aws's *shared* infrastructure rather than as a separate, reduc
 - high-level keywords (``hl_keywords``) -> relationships index (lexical + vector),
 - the entity hits are expanded through Neptune graph traversal,
 - ``mix`` additionally pulls the source chunks referenced by the matched
-  entities/relationships (following ``text_unit_ids`` lineage, ranked by how
-  many matched entities/relationships cite each chunk — LightRAG's
-  ``_find_related_text_unit_from_entities``/``_from_relationships``) and blends
-  a naive vector chunk retrieval,
+  entities/relationships (following ``text_unit_ids`` lineage, allocating slots
+  per hit by weighted polling so every match keeps at least one chunk, and
+  deduplicating against the naive vector chunk stream — LightRAG's
+  ``_find_related_text_unit_from_entities``/``_from_relations`` +
+  ``pick_by_weighted_polling`` + ``_merge_chunks``) and blends a naive vector
+  chunk retrieval,
 - everything is fused and reranked via the shared :class:`HybridScorer`
   (BM25 lexical + vector semantic + graph + RRF + Bedrock rerank).
 
@@ -22,6 +24,7 @@ and caching as the GraphRAG strategies — only the retrieval algorithm differs.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -32,6 +35,7 @@ from unified_kg_rag.adapters.retrieval.base import (
     BaseSearchStrategy,
     is_fatal_retrieval_error,
 )
+from unified_kg_rag.adapters.retrieval.token_manager import SectionType
 from unified_kg_rag.domain.models import (
     Config,
     RetrievalResult,
@@ -45,6 +49,79 @@ from unified_kg_rag.domain.retrieval.strategy_registry import register_strategy
 from unified_kg_rag.shared import get_logger
 
 logger = get_logger(__name__)
+
+# Upstream LightRAG uses TWO separate retrieval widths, not one.
+# `QueryParam.top_k` (DEFAULT_TOP_K = 40) is the width of the ENTITY and RELATIONSHIP
+# vector queries; `QueryParam.chunk_top_k` (DEFAULT_CHUNK_TOP_K = 20) is the separate
+# width of the chunk stream (lightrag/constants.py; operate.py line ~4281:
+# `search_top_k = query_param.chunk_top_k or query_param.top_k`). Collapsing both onto
+# the caller's single `top_k` starves the KG streams, because a `top_k` sized for the
+# chunk stream is far narrower than the width the entity/relationship queries need.
+#
+# `top_k` stays the caller's knob for how wide the CHUNK stream is (the axis that maps
+# onto the GraphRAG strategies' top_k). The KG streams get their own configured width
+# (`search.lightrag_search.kg_stream_top_k`, defaulting to upstream's 40), scaled up
+# from top_k when the caller asks for more than that.
+
+
+def _pick_by_weighted_polling(
+    lineages: list[list[str]],
+    max_related_chunks: int,
+    min_related_chunks: int = 1,
+) -> list[str]:
+    """Allocate chunk slots per KG hit on a linear-decreasing gradient.
+
+    Port of upstream LightRAG's ``utils.pick_by_weighted_polling`` (the default
+    ``kg_chunk_pick_method = WEIGHT`` path used by
+    ``_find_related_text_unit_from_entities``/``_from_relations``). ``lineages``
+    is one chunk-id list per matched entity/relationship, already in retrieval
+    (importance) order.
+
+    The point of the gradient is the ``min_related_chunks=1`` floor: the LAST
+    matched KG item still gets one chunk. A global "rank all lineage chunks by
+    citation count" cut — what this strategy did previously — instead
+    lets chunks cited by many entities take every slot, and the one low-citation
+    chunk that uniquely carries a multi-hop question's second hop is dropped.
+    """
+    if not lineages:
+        return []
+    n = len(lineages)
+    if n == 1:
+        return list(lineages[0][:max_related_chunks])
+
+    expected_counts = [
+        int(
+            round(
+                max_related_chunks
+                - (i / (n - 1)) * (max_related_chunks - min_related_chunks)
+            )
+        )
+        for i in range(n)
+    ]
+
+    selected: list[str] = []
+    used = []
+    total_remaining = 0
+    for lineage, expected in zip(lineages, expected_counts, strict=True):
+        actual = min(expected, len(lineage))
+        selected.extend(lineage[:actual])
+        used.append(actual)
+        total_remaining += expected - actual
+
+    # Re-distribute the quota that short lineages could not fill, one chunk per
+    # scan, so leftover slots still spread across items instead of piling onto
+    # the single richest one.
+    for _ in range(total_remaining):
+        allocated = False
+        for i, lineage in enumerate(lineages):
+            if used[i] < len(lineage):
+                selected.append(lineage[used[i]])
+                used[i] += 1
+                allocated = True
+                break
+        if not allocated:
+            break
+    return selected
 
 
 # NAIVE is vector-chunk-only (no graph), so it declares DOCUMENT-only roles;
@@ -78,6 +155,29 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
     ) -> None:
         super().__init__(config, retrievers, boto_session, **kwargs)
         self._os_config = config.indexing.opensearch
+        self._lightrag_config = config.search.lightrag_search
+
+    def _kg_stream_top_k(self, top_k: int) -> int:
+        """Width of the entity/relationship vector queries (`QueryParam.top_k`)."""
+        return max(self._lightrag_config.kg_stream_top_k, top_k)
+
+    def _chunk_stream_top_k(self, top_k: int) -> int:
+        """Width of the chunk vector query (`QueryParam.chunk_top_k`)."""
+        return max(self._lightrag_config.chunk_stream_top_k, top_k)
+
+    def _incident_fetch_limit(self) -> int:
+        """How many incident edges to request per endpoint side.
+
+        Upstream's entity->incident-edge expansion has NO count limit — it fetches
+        every edge touching the entity hits and lets the per-type TOKEN budget
+        (DEFAULT_MAX_RELATION_TOKENS = 8000) do the trimming. An OpenSearch query
+        cannot be unbounded, so ask for the largest page the retriever will
+        actually grant (`opensearch.max_query_size`) rather than a larger constant
+        the retriever would silently clamp. Applied per endpoint side, so up to
+        ~2x that many edges reach the dedup, which keeps the token budget rather
+        than a count the binding constraint, as upstream.
+        """
+        return self._os_config.max_query_size
 
     def _mode(self, query: SearchQuery) -> str:
         return str(query.metadata.get("lightrag_mode", SearchStrategy.MIX.value))
@@ -141,24 +241,130 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
                 if expanded:
                     results_by_source["graph_entities"] = expanded
 
+            # Cross-type expansion, both directions. `_relationship_endpoint_ids`
+            # above already covers relation -> endpoint entity (upstream
+            # `_find_most_related_entities_from_relationships`); this covers
+            # entity -> incident edge (`_find_most_related_edges_from_entities`),
+            # which had no counterpart at all and left the relationship stream at
+            # a third of upstream's width.
+            entity_hits = results_by_source.get("lightrag_entities", [])
+            if entity_hits:
+                incident = await self._retrieve_incident_relationships(
+                    query,
+                    entity_hits,
+                    known_relationships=results_by_source.get(
+                        "lightrag_relationships", []
+                    ),
+                )
+                if incident:
+                    results_by_source.update(incident)
+
+            # Upstream's global side derives its ENTITY
+            # context from the matched relationships' endpoints
+            # (`_find_most_related_entities_from_relationships`, fetched with
+            # `get_nodes_batch` and merged with the ll entity list in
+            # `_merge_context`). We previously fed those endpoint ids only to
+            # `_expand_via_graph` above — a Neptune re-query that returns the
+            # seeds' NEIGHBOURHOOD, not the endpoints themselves — so the
+            # endpoints never became context items and the entity section sat at
+            # 48 vs upstream's 71. Sourced from the hl VECTOR hits only, as
+            # upstream does (NOT the incident-edge expansion above).
+            relationship_hits = results_by_source.get("lightrag_relationships", [])
+            if relationship_hits:
+                endpoints = await self._retrieve_endpoint_entities(
+                    query,
+                    relationship_hits,
+                    known_entities=results_by_source.get("lightrag_entities", []),
+                )
+                if endpoints:
+                    results_by_source.update(endpoints)
+
             if mode == SearchStrategy.MIX.value:
                 # KG-grounded chunks: follow text_unit_ids lineage from the
-                # matched entities/relationships to their source chunks (ranked
-                # by citation count), then blend a naive vector chunk query.
+                # matched entities/relationships to their source chunks, then
+                # blend a naive vector chunk query.
+                #
+                # The naive vector chunks are fetched
+                # FIRST and passed to the lineage selection as `exclude`, because
+                # upstream merges the three chunk streams round-robin under one
+                # `seen_chunk_ids` set with the vector stream taking precedence
+                # (operate.py `_merge_chunks`). Selecting the lineage chunks
+                # blind to that set spent 37% of the KG chunk budget re-fetching
+                # chunks the vector query had already delivered.
+                results_by_source.update(await self._retrieve_chunks(query))
+                vector_chunk_ids = {
+                    cid
+                    for cid in self._get_ids(
+                        results_by_source.get("lightrag_chunks", []), "id"
+                    )
+                    if cid
+                }
                 linked = await self._retrieve_linked_chunks(
                     query,
                     results_by_source.get("lightrag_entities", []),
                     results_by_source.get("lightrag_relationships", []),
+                    exclude=vector_chunk_ids,
                 )
                 if linked:
                     results_by_source.update(linked)
-                results_by_source.update(await self._retrieve_chunks(query))
 
+        # Keep entities/relationships/chunks as separate streams
+        # with reserved slots (LightRAG uses ~40 entities / 20 chunks), instead of
+        # collapsing all types into one flat top_k pool where chunks get starved.
+        # Scaled off top_k: text (chunks) get the largest share since the multi-hop
+        # answer lives in them; entities/relationships get the rest. Non-mix modes and
+        # the no-quota path are unchanged.
+        per_type_quota = None
+        if mode == SearchStrategy.MIX.value:
+            k = query.top_k
+            # The quota has to match upstream's TWO widths (see the module comment on
+            # kg_stream_top_k / chunk_stream_top_k), otherwise widening the vector
+            # queries changes nothing — the fusion quota, not the query width, is what
+            # decides how much of each stream reaches the context.
+            #
+            # Upstream applies NO count cap to the KG lists —
+            # `_find_most_related_edges_from_entities` /
+            # `_find_most_related_entities_from_relationships` return every
+            # cross-expanded item and `_apply_token_truncation` trims them against
+            # per-type TOKEN limits (DEFAULT_MAX_ENTITY_TOKENS 6000 /
+            # DEFAULT_MAX_RELATION_TOKENS 8000). So the KG quotas are the *floor*
+            # `_kg_stream_top_k(k)` raised to however many candidates the expansion
+            # actually produced; TokenManager's per-type budget is what binds, exactly
+            # as upstream. (Chunks keep a hard count cap because upstream has one too:
+            # `chunk_top_k` on the merged pool — see `_select_with_type_quota`.)
+            #
+            # Only the three types mix actually retrieves are listed. A type with no
+            # quota entry is still eligible for the score-ordered back-fill, so this
+            # reserves slots without silently excluding anything.
+            candidates: dict[str, int] = {}
+            for stream in results_by_source.values():
+                for result in stream:
+                    rtype = result.retriever_type
+                    candidates[rtype] = candidates.get(rtype, 0) + 1
+            kg_floor = self._kg_stream_top_k(k)
+            per_type_quota = {
+                SectionType.TEXT.value: self._chunk_stream_top_k(k),
+                SectionType.ENTITY.value: max(
+                    kg_floor, candidates.get(SectionType.ENTITY.value, 0)
+                ),
+                SectionType.RELATIONSHIP.value: max(
+                    kg_floor, candidates.get(SectionType.RELATIONSHIP.value, 0)
+                ),
+            }
+        # For mix, rerank ONLY text chunks; keep the KG entity/relationship streams on
+        # their native (degree/cosine) order. Content-vs-query reranking buries
+        # multi-hop bridge entities/relations whose description lacks the question's
+        # surface terms (LightRAG reranks chunks only).
+        rerank_only_types = (
+            {SectionType.TEXT.value} if mode == SearchStrategy.MIX.value else None
+        )
         final_results = self.hybrid_scorer.fuse_and_rerank_results(
             results_by_source,
             top_k=query.top_k,
             retrieval_multiplier=query.retrieval_multiplier,
             query=query.query,
+            per_type_quota=per_type_quota,
+            rerank_only_types=rerank_only_types,
         )
 
         processing_time = time.time() - start_time
@@ -194,7 +400,7 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
         search_query = SearchQuery(
             query=", ".join(query.ll_keywords),
             search_type=query.search_type,
-            top_k=query.top_k,
+            top_k=self._kg_stream_top_k(query.top_k),
             index_prefixes=[self._os_config.entities_index_prefix],
             suffix=query.suffix,
         )
@@ -216,7 +422,7 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
         search_query = SearchQuery(
             query=", ".join(query.hl_keywords),
             search_type=query.search_type,
-            top_k=query.top_k,
+            top_k=self._kg_stream_top_k(query.top_k),
             index_prefixes=[self._os_config.relationships_index_prefix],
             suffix=query.suffix,
         )
@@ -238,7 +444,7 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
         search_query = SearchQuery(
             query=query.query,
             search_type=query.search_type,
-            top_k=query.top_k,
+            top_k=self._chunk_stream_top_k(query.top_k),
             index_prefixes=[self._os_config.text_units_index_prefix],
             suffix=query.suffix,
         )
@@ -252,55 +458,99 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
             return {}
 
     @staticmethod
+    def _lineages(results: list[RetrievalResult]) -> list[list[str]]:
+        """Per-hit ``text_unit_ids`` lineage, in retrieval (importance) order."""
+        lineages: list[list[str]] = []
+        for result in results:
+            metadata = result.metadata or {}
+            unit_ids = metadata.get("text_unit_ids")
+            # Neptune's `_clean_property_map` unwraps a
+            # single-element value_map list into a bare scalar, so an entity or
+            # relationship whose lineage is exactly ONE chunk arrives as a str.
+            # The old `isinstance(..., list)` guard skipped those outright,
+            # discarding precisely the most specific (single-document) bridge
+            # items — the ones multi-hop questions hinge on.
+            if isinstance(unit_ids, str):
+                unit_ids = [unit_ids]
+            if not isinstance(unit_ids, list):
+                continue
+            lineage = [uid for uid in unit_ids if isinstance(uid, str) and uid]
+            if lineage:
+                lineages.append(lineage)
+        return lineages
+
     def _collect_linked_chunk_ids(
+        self,
         entity_results: list[RetrievalResult],
         relationship_results: list[RetrievalResult],
         limit: int,
+        exclude: set[str] | None = None,
     ) -> list[str]:
-        """Rank source chunk ids by how many matched KG items cite them.
+        """Select the source chunks cited by the matched entities/relationships.
 
-        Mirrors LightRAG's ``_find_related_text_unit_from_entities``/
-        ``_from_relationships``: each matched entity/relationship contributes the
-        chunks in its ``text_unit_ids`` lineage; chunks cited by more matched
-        items are more central to the query and ranked first. Ties keep first-
-        seen order so ranking is deterministic.
+        Mirrors upstream LightRAG's two-stage selection
+        (``_find_related_text_unit_from_entities`` then ``_from_relations``):
+
+        1. per-hit lineages are deduplicated keeping the EARLIEST (most
+           important) citing hit, so a chunk occupies one item's quota, not many;
+        2. slots are allocated by :func:`_pick_by_weighted_polling`, which
+           guarantees every matched hit at least one chunk;
+        3. relationship lineages additionally drop chunks already selected from
+           the entity side, and — via ``exclude`` — chunks the naive vector
+           stream already returned (upstream ``operate.py`` passes
+           ``entity_chunks`` into the relation pass for exactly this, then
+           round-robin merges the three streams under one ``seen_chunk_ids``).
+
+        The previous implementation ranked the pooled lineage by global citation
+        count and cut at ``limit``, with no dedup against the vector chunk stream, so
+        a large share of the linked stream spent slots on chunks the vector stream had
+        already retrieved.
         """
-        counts: dict[str, int] = {}
-        order: dict[str, int] = {}
-        seq = 0
-        for result in [*entity_results, *relationship_results]:
-            metadata = result.metadata or {}
-            unit_ids = metadata.get("text_unit_ids")
-            if not isinstance(unit_ids, list):
-                continue
-            for uid in unit_ids:
-                if not isinstance(uid, str) or not uid:
-                    continue
-                if uid not in counts:
-                    counts[uid] = 0
-                    order[uid] = seq
-                    seq += 1
-                counts[uid] += 1
-        ranked = sorted(counts, key=lambda uid: (-counts[uid], order[uid]))
-        return ranked[:limit]
+        excluded = set(exclude or ())
+
+        def _select(results: list[RetrievalResult]) -> list[str]:
+            deduped: list[list[str]] = []
+            for lineage in self._lineages(results):
+                keep = [uid for uid in lineage if uid not in excluded]
+                # Keep the chunk on its earliest (most important) citing hit only.
+                excluded.update(keep)
+                if keep:
+                    deduped.append(keep)
+            return _pick_by_weighted_polling(
+                deduped, self._lightrag_config.related_chunk_number
+            )
+
+        selected = _select(entity_results) + _select(relationship_results)
+        return selected[:limit]
 
     async def _retrieve_linked_chunks(
         self,
         query: SearchQuery,
         entity_results: list[RetrievalResult],
         relationship_results: list[RetrievalResult],
+        exclude: set[str] | None = None,
     ) -> dict[str, list[RetrievalResult]]:
         """Fetch the source chunks cited by the matched entities/relationships.
 
         Collects ``text_unit_ids`` lineage from the entity/relationship hits,
-        ranks chunk ids by citation count, and fetches the top chunks by id from
-        the text-units index. Degrades to no section if lineage is absent (e.g.
-        an index built before lineage was added) or retrieval fails.
+        allocates chunk slots per hit by weighted polling, and fetches the
+        selected chunks by id from the text-units index. ``exclude`` carries the
+        chunk ids the naive vector stream already returned.
+        Degrades to no section if lineage is absent (e.g. an index built before
+        lineage was added) or retrieval fails.
         """
         if not self.document_retriever:
             return {}
+        # The lineage pool is a CHUNK stream, so it is bounded by
+        # upstream's chunk width, not by the caller's top_k. Upstream bounds it in two
+        # steps — `related_chunk_number` (5) chunks per matched entity/relationship, then
+        # a truncation of the combined pool to `chunk_top_k` — so with 40 KG hits its
+        # pool is far larger than a flat top_k=10 before the final cut.
         chunk_ids = self._collect_linked_chunk_ids(
-            entity_results, relationship_results, limit=query.top_k
+            entity_results,
+            relationship_results,
+            limit=self._chunk_stream_top_k(query.top_k),
+            exclude=exclude,
         )
         if not chunk_ids:
             return {}
@@ -328,6 +578,12 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
         Relationship documents carry their endpoint entity ids in metadata
         (``source_id``/``target_id``); these ground a high-level (relationship)
         hit back to the graph so it can be expanded like an entity hit.
+
+        Deduplicated in FIRST-SEEN order (src before tgt, edge by edge), which is
+        the order upstream's ``_find_most_related_entities_from_relationships``
+        builds ``entity_names`` in and then rebuilds ``node_datas`` to match. The
+        order is load-bearing: the KG streams are not reranked (only ``text`` is),
+        so stream position is what decides which endpoints survive fusion.
         """
         endpoint_ids: list[str] = []
         for result in relationship_results:
@@ -336,7 +592,186 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
                 value = metadata.get(field)
                 if isinstance(value, str) and value:
                     endpoint_ids.append(value)
-        return endpoint_ids
+        return list(dict.fromkeys(endpoint_ids))
+
+    async def _retrieve_endpoint_entities(
+        self,
+        query: SearchQuery,
+        relationship_results: list[RetrievalResult],
+        known_entities: list[RetrievalResult] | None = None,
+    ) -> dict[str, list[RetrievalResult]]:
+        """The endpoint entities of the hl relationship hits.
+
+        Upstream's global side does not run an entity vector query at all — its
+        entity context comes entirely from the matched relationships:
+        ``_get_edge_data`` (operate.py ~5419) hands its ``edge_datas`` to
+        ``_find_most_related_entities_from_relationships`` (~5478), which collects
+        every ``src_id``/``tgt_id`` in first-seen order and fetches those nodes via
+        ``get_nodes_batch``. In hybrid/mix the result is round-robin merged with the
+        local (ll vector) entity list under one ``seen_entities`` set
+        (``_merge_context``). That is how upstream's entity section grows well past
+        the width of the entity vector query itself.
+
+        We previously fed these endpoint ids into ``_expand_via_graph`` — a Neptune
+        re-query of the seeds, which returns the seeds' neighborhood, not the
+        endpoints themselves as context items. This emits them as first-class entity
+        candidates instead.
+
+        Only the hl VECTOR hits are used as the source, not the
+        incident-edge expansion: upstream's endpoint pass runs inside
+        ``_get_edge_data`` on the vector results only, and feeding it ~130 incident
+        edges would manufacture entities upstream never has.
+        """
+        retriever = self.document_retriever
+        if not retriever:
+            return {}
+        already = {eid for eid in self._get_ids(known_entities or [], "id") if eid}
+        endpoint_ids = [
+            eid
+            for eid in self._relationship_endpoint_ids(relationship_results)
+            if eid not in already
+        ]
+        if not endpoint_ids:
+            return {}
+        search_query = SearchQuery(
+            query="",
+            search_type=SearchType.LEXICAL,
+            top_k=len(endpoint_ids),
+            index_prefixes=[self._os_config.entities_index_prefix],
+            suffix=query.suffix,
+            filters={"id": endpoint_ids},
+        )
+        try:
+            results = await retriever.aretrieve(search_query)
+        except Exception as e:
+            if is_fatal_retrieval_error(e):
+                raise
+            logger.error("Endpoint entity retrieval failed: %s", e)
+            return {}
+        if not results:
+            return {}
+        # Restore the endpoint order the fetch-by-id lost (OpenSearch returns a
+        # terms filter's hits in score/index order, not in the order asked for);
+        # upstream rebuilds `node_datas` in `entity_names` order for this reason.
+        order = {eid: i for i, eid in enumerate(endpoint_ids)}
+
+        def _position(result: RetrievalResult) -> int:
+            metadata = result.metadata or {}
+            eid = str(metadata.get("id") or result.source or "")
+            return order.get(eid, len(order))
+
+        results.sort(key=_position)
+        logger.info(
+            "Endpoint expansion: %s relationship hits -> %s endpoint entities",
+            len(relationship_results),
+            len(results),
+        )
+        return {"lightrag_endpoint_entities": results}
+
+    @staticmethod
+    def _endpoint_pair(result: RetrievalResult) -> tuple[str, str]:
+        """The undirected endpoint key upstream dedups edges by (`tuple(sorted(e))`)."""
+        metadata = result.metadata or {}
+        return tuple(  # type: ignore[return-value]
+            sorted((str(metadata.get("source_id")), str(metadata.get("target_id"))))
+        )
+
+    async def _retrieve_incident_relationships(
+        self,
+        query: SearchQuery,
+        entity_results: list[RetrievalResult],
+        known_relationships: list[RetrievalResult] | None = None,
+    ) -> dict[str, list[RetrievalResult]]:
+        """Every relationship INCIDENT to a matched entity.
+
+        Upstream LightRAG's `_find_most_related_edges_from_entities` (operate.py
+        ~5204) takes the entity vector hits, pulls **all** edges incident to them
+        via `get_nodes_edges_batch`, dedups by sorted endpoint pair, and orders by
+        `(rank, weight)` — with no top_k cut. That cross-type expansion is where the
+        bulk of upstream's relationship context comes from; the relationship vector
+        query alone supplies a small fraction of it. The relationship stream was never
+        truncated on OUR side — the candidates simply did not exist.
+
+        The relationships index stores its endpoints as `source_id`/`target_id`
+        keywords, but `_build_filter_clauses` ANDs every filter, so
+        `source_id OR target_id` needs two queries. `known_relationships` carries
+        the hl vector query's hits, which are dropped from this stream by ENDPOINT
+        PAIR (not doc id) — that is the key upstream's round-robin merge of the
+        local and global relation lists dedups on (`_merge_context` builds
+        `rel_key = tuple(sorted([src_id, tgt_id]))` over one `seen_relations` set).
+        """
+        retriever = self.document_retriever
+        if not retriever:
+            return {}
+        entity_ids = [eid for eid in self._get_ids(entity_results, "id") if eid]
+        if not entity_ids:
+            return {}
+
+        page = self._incident_fetch_limit()
+
+        async def _by_endpoint(field: str) -> list[RetrievalResult]:
+            search_query = SearchQuery(
+                query="",
+                search_type=SearchType.LEXICAL,
+                top_k=page,
+                index_prefixes=[self._os_config.relationships_index_prefix],
+                suffix=query.suffix,
+                filters={field: entity_ids},
+            )
+            side = await retriever.aretrieve(search_query)
+            # A full page means the count cap bound and edges were dropped —
+            # upstream drops none. Say so rather than let a silent truncation read
+            # as "all edges".
+            if len(side) >= page:
+                logger.warning(
+                    "Incident-edge fetch on %s hit the %s-hit page cap; "
+                    "the expansion is truncated (upstream truncates by tokens only)",
+                    field,
+                    page,
+                )
+            return side
+
+        try:
+            sides = await asyncio.gather(
+                _by_endpoint("source_id"), _by_endpoint("target_id")
+            )
+        except Exception as e:
+            if is_fatal_retrieval_error(e):
+                raise
+            logger.error("Incident relationship retrieval failed: %s", e)
+            return {}
+
+        # Dedup by the undirected endpoint pair, as upstream does (`tuple(sorted(e))`),
+        # so an edge reachable from both of its endpoints is carried once — and so an
+        # edge the hl vector query already returned is not paid for twice.
+        seen: set[tuple[str, str]] = {
+            self._endpoint_pair(r) for r in (known_relationships or [])
+        }
+        deduped: list[RetrievalResult] = []
+        for result in [r for side in sides for r in side]:
+            pair = self._endpoint_pair(result)
+            if pair in seen:
+                continue
+            seen.add(pair)
+            deduped.append(result)
+
+        if not deduped:
+            return {}
+        # Upstream orders these by (rank, weight) descending — degree first, so the
+        # hub edges that carry a multi-hop chain outrank incidental leaf edges.
+        deduped.sort(
+            key=lambda r: (
+                float((r.metadata or {}).get("rank") or 0.0),
+                float((r.metadata or {}).get("weight") or 0.0),
+            ),
+            reverse=True,
+        )
+        logger.info(
+            "Incident expansion: %s entity hits -> %s incident relationships",
+            len(entity_ids),
+            len(deduped),
+        )
+        return {"lightrag_incident_relationships": deduped}
 
     async def _expand_via_graph(
         self, query: SearchQuery, seed_entity_ids: list[str]

--- a/unified_kg_rag/adapters/search_strategies/local_search.py
+++ b/unified_kg_rag/adapters/search_strategies/local_search.py
@@ -10,6 +10,7 @@ from unified_kg_rag.adapters.retrieval.base import (
     BaseSearchStrategy,
     is_fatal_retrieval_error,
 )
+from unified_kg_rag.adapters.retrieval.token_manager import SectionType
 from unified_kg_rag.domain.models import (
     Config,
     RetrievalResult,
@@ -36,6 +37,37 @@ class LocalSearchStrategy(BaseSearchStrategy):
     ):
         super().__init__(config, retrievers, boto_session, **kwargs)
         self.entity_focus_multiplier = entity_focus_multiplier
+
+    def _per_type_quota(self, top_k: int) -> dict[str, int]:
+        """Reserved fusion slots per section type, from configured shares of top_k."""
+        quota_config = self.config.search.local_search.type_quota
+        shares: list[tuple[SectionType, float, int]] = [
+            (SectionType.TEXT, quota_config.text_multiplier, quota_config.text_floor),
+            (
+                SectionType.ENTITY,
+                quota_config.entity_multiplier,
+                quota_config.entity_floor,
+            ),
+            (
+                SectionType.RELATIONSHIP,
+                quota_config.relationship_multiplier,
+                quota_config.relationship_floor,
+            ),
+            (
+                SectionType.COMMUNITY,
+                quota_config.community_multiplier,
+                quota_config.community_floor,
+            ),
+            (
+                SectionType.CLAIM,
+                quota_config.claim_multiplier,
+                quota_config.claim_floor,
+            ),
+        ]
+        return {
+            section_type.value: max(int(multiplier * top_k), floor)
+            for section_type, multiplier, floor in shares
+        }
 
     async def asearch(self, query: SearchQuery) -> SearchResult:
         start_time = time.time()
@@ -70,7 +102,7 @@ class LocalSearchStrategy(BaseSearchStrategy):
             "..." if len(expanded_entity_ids) > 5 else "",
         )
 
-        text_unit_ids = self._get_ids(filtered_entity_nodes, "text_unit_ids")
+        text_unit_ids = self._rank_text_unit_ids(filtered_entity_nodes)
         logger.debug(
             "Found %s text units: '%s%s'",
             len(text_unit_ids),
@@ -102,11 +134,19 @@ class LocalSearchStrategy(BaseSearchStrategy):
         if claims:
             all_results["claims"] = claims
 
+        # The same divergences as mix apply to local (shared fuse path).
+        # Give each section type its own quota so the diversity filter + fusion don't
+        # collapse the candidate set to top_k before assembly (was dropping gold KG
+        # items), and rerank ONLY text chunks so content-vs-query reranking doesn't bury
+        # multi-hop bridge entities/relations. Mirrors MS local's proportional,
+        # per-section context assembly.
         final_results = self.hybrid_scorer.fuse_and_rerank_results(
             all_results,
             top_k=query.top_k,
             retrieval_multiplier=query.retrieval_multiplier,
             query=query.query,
+            per_type_quota=self._per_type_quota(query.top_k),
+            rerank_only_types={SectionType.TEXT.value},
         )
 
         processing_time = time.time() - start_time
@@ -278,14 +318,68 @@ class LocalSearchStrategy(BaseSearchStrategy):
             logger.error("Neptune retrieval failed: %s", e)
             return []
 
+    @classmethod
+    def _rank_text_unit_ids(cls, entity_nodes: list[RetrievalResult]) -> list[str]:
+        # Chunk candidates used to come from
+        # `_get_ids(nodes, "text_unit_ids")`, which unions them into a SET — so
+        # all ordering was lost, and `_retrieve_documents` then fetches them by
+        # id filter with `query=""` (an ID batch fetch, no relevance score). The
+        # chunk stream therefore reached fusion in arbitrary order with score 0,
+        # and whatever the per-type quota sliced off was an arbitrary subset.
+        # That is invisible while expansion is narrow and every chunk is
+        # on-topic, but it makes widening the expansion actively harmful: a
+        # measured 5x more chunks came with 4x LESS gold in the context.
+        #
+        # MS GraphRAG local ranks candidate text units by how many distinct
+        # query-relevant entities reference them, with the entity's own rank as
+        # the tiebreak, before applying its text-unit budget. Mirror that here:
+        # score each chunk by (number of referencing entities, best referencing
+        # entity score) and return ids in descending order, so downstream
+        # truncation keeps the chunks with the most graph support.
+        hit_count: dict[str, int] = {}
+        best_score: dict[str, float] = {}
+        for node in entity_nodes:
+            ids = node.metadata.get("text_unit_ids") or []
+            if isinstance(ids, str):
+                ids = [ids]
+            if not isinstance(ids, list):
+                continue
+            score = node.score or 0.0
+            for raw_id in ids:
+                unit_id = str(raw_id)
+                hit_count[unit_id] = hit_count.get(unit_id, 0) + 1
+                if score > best_score.get(unit_id, float("-inf")):
+                    best_score[unit_id] = score
+        return sorted(
+            hit_count,
+            key=lambda unit_id: (hit_count[unit_id], best_score.get(unit_id, 0.0)),
+            reverse=True,
+        )
+
     @staticmethod
+    def _text_unit_count(node: RetrievalResult) -> int:
+        # Neptune's `_clean_property_map` unwraps any
+        # single-element value_map list into a bare scalar, so an entity that
+        # appears in EXACTLY ONE text unit arrives with `text_unit_ids` as a str
+        # (a 36-char UUID), not a list. `len()` on that counted CHARACTERS (36),
+        # which exceeds every sane frequency threshold, so the most specific
+        # entities in the graph — the multi-hop bridge nodes that occur in a
+        # single document — were silently dropped by the frequency filter, which
+        # also starved the text-unit fan-out those entities feed.
+        ids = node.metadata.get("text_unit_ids") or []
+        if isinstance(ids, str):
+            return 1
+        return len(ids)
+
+    @classmethod
     def _filter_entities(
+        cls,
         expanded_entity_nodes: list[RetrievalResult],
         frequency_threshold: int,
     ) -> list[RetrievalResult]:
         filtered_nodes = []
         for node in expanded_entity_nodes:
-            text_unit_count = len(node.metadata.get("text_unit_ids", []))
+            text_unit_count = cls._text_unit_count(node)
             if 0 < text_unit_count <= frequency_threshold or text_unit_count == 0:
                 filtered_nodes.append(node)
 
@@ -317,12 +411,37 @@ class LocalSearchStrategy(BaseSearchStrategy):
 
         try:
             results = await self.document_retriever.aretrieve(search_query)
-            return {"text_units": results}
+            return {"text_units": self._restore_rank(results, text_unit_ids)}
         except Exception as e:
             if is_fatal_retrieval_error(e):
                 raise
             logger.error("OpenSearch retrieval failed: %s", e)
             return {}
+
+    @staticmethod
+    def _restore_rank(
+        results: list[RetrievalResult], ranked_ids: list[str]
+    ) -> list[RetrievalResult]:
+        # This lookup is an ID-batch FETCH (`query=""`,
+        # LEXICAL, pure id filter), so OpenSearch returns the batch in index
+        # order with no meaningful relevance score — 1915 of 2355 emitted
+        # contexts carried score 0.0. That threw away the graph-support ranking
+        # computed in `_rank_text_unit_ids`. Re-impose it here, and project it
+        # into `score` as a normalized descending value so the shared fusion /
+        # per-type-quota path (which sorts by score) preserves it instead of
+        # tie-breaking arbitrarily.
+        if not results or not ranked_ids:
+            return results
+        rank_of = {unit_id: i for i, unit_id in enumerate(ranked_ids)}
+        fallback = len(ranked_ids)
+        ordered = sorted(results, key=lambda r: rank_of.get(str(r.source), fallback))
+        total = len(ordered)
+        rescored: list[RetrievalResult] = []
+        for position, result in enumerate(ordered):
+            scored = result.model_copy()
+            scored.score = (total - position) / total
+            rescored.append(scored)
+        return rescored
 
     def _record_search_metrics(
         self,

--- a/unified_kg_rag/application/retrieval/rag_chain.py
+++ b/unified_kg_rag/application/retrieval/rag_chain.py
@@ -706,8 +706,16 @@ class GraphRAGChain(Runnable[RAGInput, RAGOutput | dict[str, Any]]):
     def _format_output_step(state: dict[str, Any]) -> RAGOutput:
         sr: SearchResult = state["search_results"]
         sr.search_strategy = state["resolved_strategy"].value
+        # `content` carries the retrieved TEXT. Omitting it made every vector-retriever
+        # result serialise to {"source": <uuid>, "score": <f>} only (its metadata holds
+        # no description/name), so `retrieved_contexts` opened with ~20 text-free
+        # entries: any consumer that truncates to top-k saw no text at all. That
+        # silently zeroed offline context-recall scoring AND starved the RAGAS context
+        # metrics for the highest-scoring results. Retrieval and generation are
+        # unaffected — this is what gets REPORTED, not what gets retrieved.
         sources = [
-            r.model_dump(include={"source", "score", "metadata"}) for r in sr.results
+            r.model_dump(include={"content", "source", "score", "metadata"})
+            for r in sr.results
         ]
 
         metadata = {

--- a/unified_kg_rag/domain/models/config.py
+++ b/unified_kg_rag/domain/models/config.py
@@ -1318,12 +1318,59 @@ class GlobalSearchConfig(BaseModel):
     )
 
 
+class LocalSearchQuotaConfig(BaseModel):
+    """Reserved fusion slots per section type, as multiples of the query's top_k.
+
+    Without reserved slots a single type (usually entities, which arrive with many
+    near-tie fusion scores) takes the whole flat top_k cut and crowds out the
+    document chunks that carry the answer. MS GraphRAG's local search assembles
+    its context the same way — proportional per-section budgets rather than one
+    ranked list — with ``top_k_entities``/``top_k_relationships`` defaulting to 10.
+
+    Each entry is ``max(multiplier * top_k, floor)``, so the shape holds as the
+    caller's top_k scales while a small top_k still admits enough of each type.
+    """
+
+    text_multiplier: float = Field(
+        default=2.0, gt=0.0, description="Chunk slots as a multiple of top_k"
+    )
+    text_floor: int = Field(
+        default=20, ge=1, description="Minimum chunk slots regardless of top_k"
+    )
+    entity_multiplier: float = Field(
+        default=1.0, gt=0.0, description="Entity slots as a multiple of top_k"
+    )
+    entity_floor: int = Field(
+        default=10, ge=1, description="Minimum entity slots regardless of top_k"
+    )
+    relationship_multiplier: float = Field(
+        default=1.0, gt=0.0, description="Relationship slots as a multiple of top_k"
+    )
+    relationship_floor: int = Field(
+        default=10, ge=1, description="Minimum relationship slots regardless of top_k"
+    )
+    community_multiplier: float = Field(
+        default=0.5, gt=0.0, description="Community report slots as a multiple of top_k"
+    )
+    community_floor: int = Field(
+        default=2, ge=1, description="Minimum community report slots"
+    )
+    claim_multiplier: float = Field(
+        default=0.5, gt=0.0, description="Claim slots as a multiple of top_k"
+    )
+    claim_floor: int = Field(default=2, ge=1, description="Minimum claim slots")
+
+
 class LocalSearchConfig(BaseModel):
     entity_frequency_threshold: int = Field(
         default=20,
         ge=1,
         description="Drop graph-expanded entities appearing in more than this "
         "many text units (too generic to be discriminative for local search).",
+    )
+    type_quota: LocalSearchQuotaConfig = Field(
+        default_factory=LocalSearchQuotaConfig,
+        description="Reserved fusion slots per section type",
     )
 
 
@@ -1409,6 +1456,72 @@ class DriftSearchConfig(BaseModel):
     )
 
 
+class ContextTypeBudgetConfig(BaseModel):
+    """Per-section-type share of the answer context window.
+
+    Both upstream methodologies split the context window into per-type
+    sub-budgets and pack each type independently, so document chunks (which hold
+    the multi-hop answer) are guaranteed representation instead of competing in a
+    flat greedy fill of near-tie fusion scores: MS GraphRAG's ``mixed_context``
+    packs community / entity / text-unit sections against independent budgets
+    (``community_prop`` 0.15, ``text_unit_prop`` 0.5 by default), and LightRAG's
+    ``_apply_token_truncation`` trims entities / relations / chunks against
+    separate token limits (6000 / 8000 out of a 30000 window).
+
+    Shares are relative weights, not fractions: they are renormalized over the
+    section types actually present in a query's candidate set, so an absent type
+    does not shrink the usable window. Raise ``text`` to favour verbatim source
+    passages, raise ``community`` to favour high-level synthesis.
+    """
+
+    text: float = Field(
+        default=0.50, ge=0.0, description="Relative share for document chunk sections"
+    )
+    entity: float = Field(
+        default=0.20, ge=0.0, description="Relative share for graph entity sections"
+    )
+    relationship: float = Field(
+        default=0.13,
+        ge=0.0,
+        description="Relative share for graph relationship sections",
+    )
+    community: float = Field(
+        default=0.10,
+        ge=0.0,
+        description="Relative share for community report sections",
+    )
+    claim: float = Field(
+        default=0.07,
+        ge=0.0,
+        description="Relative share for claim (covariate) sections",
+    )
+    general: float = Field(
+        default=0.10,
+        ge=0.0,
+        description="Relative share for untyped sections — global search's "
+        "map-reduce synthesis and drift search's primer answer land here.",
+    )
+
+    @model_validator(mode="after")
+    def validate_at_least_one_positive_share(self) -> "ContextTypeBudgetConfig":
+        if not any(
+            share > 0.0
+            for share in (
+                self.text,
+                self.entity,
+                self.relationship,
+                self.community,
+                self.claim,
+                self.general,
+            )
+        ):
+            raise ValueError(
+                "At least one context type budget share must be greater than zero; "
+                "all-zero shares would leave every answer context empty."
+            )
+        return self
+
+
 class TokenManagerConfig(BaseModel):
     max_context_tokens: int = Field(
         default=200000,
@@ -1419,6 +1532,16 @@ class TokenManagerConfig(BaseModel):
         default=1024,
         ge=1,
         description="Maximum number of entries in the LRU cache for Bedrock token counting",
+    )
+    type_budgets: ContextTypeBudgetConfig = Field(
+        default_factory=ContextTypeBudgetConfig,
+        description="Per-section-type shares of the context window",
+    )
+    min_truncated_section_tokens: int = Field(
+        default=64,
+        ge=1,
+        description="A section truncated below this many tokens is dropped rather "
+        "than emitted as an unusable fragment of evidence.",
     )
 
 
@@ -1431,6 +1554,34 @@ class LightRAGSearchConfig(BaseModel):
             "length is below this (0 disables the gate) falls back to using the raw "
             "query as a low-level keyword, mirroring LightRAG. Longer queries skip "
             "the fallback to avoid an over-broad graph scan."
+        ),
+    )
+    kg_stream_top_k: int = Field(
+        default=40,
+        ge=1,
+        description=(
+            "Width of the entity and relationship vector queries (LightRAG's "
+            "`QueryParam.top_k`, default 40). Separate from the chunk width: "
+            "collapsing both onto the caller's single top_k starves the graph "
+            "streams. Acts as a floor — a caller asking for a larger top_k gets it."
+        ),
+    )
+    chunk_stream_top_k: int = Field(
+        default=20,
+        ge=1,
+        description=(
+            "Width of the chunk stream, and the cap on the merged chunk pool "
+            "(LightRAG's `QueryParam.chunk_top_k`, default 20). Acts as a floor "
+            "against the caller's top_k."
+        ),
+    )
+    related_chunk_number: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            "Chunks allocated per matched entity/relationship when following "
+            "`text_unit_ids` lineage (LightRAG's `related_chunk_number`). Slots are "
+            "distributed on a decreasing gradient so the last match still gets one."
         ),
     )
 

--- a/unified_kg_rag/evaluation/evaluation_manager.py
+++ b/unified_kg_rag/evaluation/evaluation_manager.py
@@ -265,6 +265,10 @@ class EvaluationManager:
         desired_fields = [
             "description",
             "full_content",
+            # `content` is RetrievalResult's text field — the vector retriever populates
+            # it and nothing else, so without it those results fell through to
+            # _create_minimal_info and were stored as id+score with no text.
+            "content",
             "name",
             "summary",
             translated_key,


### PR DESCRIPTION
## Summary

Context assembly for the `local` and `mix` strategies had its tuning constants embedded in module scope, and several of them were applied inconsistently with the upstream algorithms this library reimplements. This turns those constants into validated configuration and fixes the inconsistencies.

## New configuration

All knobs are Pydantic fields documented in `config-template.yaml`.

| Knob | Replaces | Purpose |
|---|---|---|
| `search.lightrag_search.kg_stream_top_k` | `KG_STREAM_TOP_K` | width of the entity/relationship vector queries |
| `search.lightrag_search.chunk_stream_top_k` | `CHUNK_STREAM_TOP_K` | width of the chunk stream |
| `search.lightrag_search.related_chunk_number` | `RELATED_CHUNK_NUMBER` | bound on linked-chunk selection |
| `search.token_manager.type_budgets` | `TokenManager.TYPE_BUDGET_PROP` | per-section-type share of the context window |
| `search.token_manager.min_truncated_section_tokens` | `MIN_TRUNCATED_SECTION_TOKENS` | floor below which a truncated section is dropped |
| `search.local_search.type_quota` | inline literals in `local_search.asearch` | per-type fusion quota (multiplier of `top_k` + floor) |

`kg_stream_top_k` and `chunk_stream_top_k` act as **floors**: a caller asking for a wider `top_k` is not narrowed back down. Upstream LightRAG uses two separate widths (`QueryParam.top_k` for the KG vector queries, `QueryParam.chunk_top_k` for the chunk stream); collapsing both onto one caller value starves the KG streams.

`ContextTypeBudgetConfig` has a validator rejecting an all-zero configuration, which would otherwise mean "never emit a context".

## Behaviour fixes

- **`GENERAL` sections were dropped silently.** `GENERAL` carried a hardcoded `0.0` budget share, so renormalizing over the types present in a result set gave it a zero budget whenever it co-occurred with any other type. Global search's synthesized answer and drift's primer answer both arrive as `GENERAL`, so both were discarded in any mixed result set. The old equal-share fallback only fired when `GENERAL` was the *only* type present, which is why existing tests did not catch it. `GENERAL` now has a real, configurable share.
- **Non-empty context is now guaranteed.** Shares divide across present types but the truncation floor does not, so a narrow window with several present types could drive every type's share below the floor and return an empty context while a whole section still fit. The highest-priority section is now seated in that case.
- **Per-type budgets are a hard cap.** Each type is packed against its own cap with no pooled second pass, mirroring MS GraphRAG's `mixed_context` and LightRAG's `_apply_token_truncation`. The first overflowing section is truncated to fit rather than dropping its whole type.
- **Linked-chunk selection.** The merged pool is bounded by the chunk width, deduped against the vector chunk stream, and selected by weighted polling with a floor of one chunk per lineage, so the last entity/relation still contributes.
- **Cross-type expansion.** Entities expand to their incident relationships, and relationship endpoints become first-class entity candidates rather than graph-traversal seeds only (a re-query returns the seeds' neighborhood, not the endpoints themselves).
- **Relationship serialization** now names both endpoints; the indexed `source_name`/`target_name` fields were never rendered, producing lines the reader cannot resolve.
- **Incident-relationship paging** requests the width the retriever will actually grant (`opensearch.max_query_size`). The previous constant was larger and always clamped away, so the truncation warning could never fire correctly.
- **RRF native-score blend** is scaled to one adjacent-rank step derived from `rrf_k` (`1/(k+1) - 1/(k+2)`) instead of a fixed `1/k²`, so it tracks a reconfigured `k` and cannot invert a genuine cross-stream rank gap.
- **Dead quota entries removed** for section types `mix` never queries.

## Notes

- Quota and budget keys are `SectionType` members rather than bare strings.
- `tests/unit/test_config_template_knobs.py` guards `config-template.yaml` against drifting from the model defaults — a documented knob that fails to parse, or whose documented value no longer matches the default, fails the build.
- No behaviour is gated on a dataset, query, or corpus identifier.

## Testing

`ruff`, `black`, `isort`, `mypy` clean; `pytest -m "not aws"` 1802 passed / 5 deselected, coverage 81.19% (gate 78%).