### PR TITLE
feat(bedrock): add Claude 5 models and derive context budget from window

### DIFF
--- a/config-template.yaml
+++ b/config-template.yaml
@@ -10,6 +10,17 @@ aws:
     region_name: "ap-northeast-2"
     assumed_role_arn: null
     enable_global_profile: true
+    # Opt into the 1M-token context window on models that offer it as a beta
+    # (Sonnet 4/4.5, Opus 4/4.1/4.5). Off by default — long-context requests are
+    # billed at a premium there. Claude 5 has a native 1M window and ignores
+    # this. Turning it on also widens the derived retrieval context budget.
+    enable_1m_context: false
+    # Reasoning effort for adaptive-thinking models (Claude 4.7 and later),
+    # which replaced the fixed thinking token budget. One of: low, medium,
+    # high (default), xhigh, max. Lower levels trade reasoning depth for cost
+    # and latency; xhigh/max are only accepted by some models (e.g. Opus 5).
+    # Ignored by older models, which still use thinking_budget_tokens.
+    effort: "high"
     # Amazon Bedrock Guardrails (WAF security pillar). Disabled unless an
     # identifier is set; when set, every LLM call enforces the guardrail's
     # content/PII/grounding policies on prompts and completions.
@@ -60,7 +71,7 @@ aws:
 # Global Output Fixing Configuration (auto-repair malformed model responses)
 fixing:
   enabled: true
-  fixing_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+  fixing_model_id: "anthropic.claude-sonnet-5"
 
 # Data Processing Configuration
 processing:
@@ -110,7 +121,7 @@ processing:
 
   # Graph Extraction
   graph_extraction:
-    extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    extraction_model_id: "anthropic.claude-sonnet-5"
     max_entities_per_chunk: 50
     max_relationships_per_chunk: 50
     entity_confidence_threshold: 0.0
@@ -159,7 +170,7 @@ processing:
   # Gleaning (Iterative Information Extraction)
   gleaning:
     enabled: true
-    graph_refinement_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    graph_refinement_model_id: "anthropic.claude-sonnet-5"
     max_rounds: 3
     convergence_threshold: 0.8
     quality_threshold: 0.9
@@ -181,7 +192,7 @@ processing:
     # claims index in its sweep. Claims subject/object are still not linked into
     # the entity graph.
     enabled: false
-    extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    extraction_model_id: "anthropic.claude-sonnet-5"
     max_entities_per_prompt: 100
 
 # Graph Configuration
@@ -230,7 +241,7 @@ graph:
     # Community report generation
     report_generation:
       enabled: true
-      report_generation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+      report_generation_model_id: "anthropic.claude-sonnet-5"
       max_entities_per_report: 50
       # Token budget for the entity/relationship context packed into a report
       # prompt. Entities are degree-sorted (most-connected first) and packed up
@@ -385,10 +396,10 @@ indexing:
 # Search Configuration
 search:
   translation_model_id: "anthropic.claude-haiku-4-5-20251001-v1:0"
-  entity_extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
-  strategy_selection_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
-  context_building_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
-  answer_generation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+  entity_extraction_model_id: "anthropic.claude-sonnet-5"
+  strategy_selection_model_id: "anthropic.claude-sonnet-5"
+  context_building_model_id: "anthropic.claude-sonnet-5"
+  answer_generation_model_id: "anthropic.claude-sonnet-5"
 
   # Hybrid search weights
   hybrid:
@@ -512,7 +523,14 @@ search:
 
   # Token Manager Configuration
   token_manager:
-    max_context_tokens: 200000
+    # Prompt-side context budget. Leave null to derive it from the answer
+    # model's own window minus its output reservation and the headroom below —
+    # a hardcoded number overflows a smaller model's window and wastes a larger
+    # one. An explicit value is honoured but clamped to what the model accepts.
+    max_context_tokens: null
+    # Share of the window held back for the system prompt, question, history,
+    # and token-estimation error when deriving the budget above.
+    context_window_headroom_ratio: 0.1
     token_count_cache_size: 1024
     # A section truncated below this many tokens is dropped rather than emitted
     # as an unusable fragment.
@@ -553,7 +571,7 @@ logging:
 evaluation:
   outputs_directory: "outputs/evaluation"
   embedding_model_id: "amazon.titan-embed-text-v2:0"
-  evaluation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+  evaluation_model_id: "anthropic.claude-sonnet-5"
   enabled_evaluators:
     - langchain
     - ragas

--- a/docs/design.ko.md
+++ b/docs/design.ko.md
@@ -274,7 +274,7 @@ grep으로 검증: `domain/`은 런타임에 `adapters`/`application`을 import�
 
 | 서비스 | 모듈 | 용도 |
 |---|---|---|
-| **Bedrock** | `adapters/aws/bedrock.py` | LLM/임베딩/리랭킹. cross-region inference profile 자동 해석, thinking 모드, 1M 컨텍스트, prompt 캐싱, capability 테이블 |
+| **Bedrock** | `adapters/aws/bedrock.py` | LLM/임베딩/리랭킹. cross-region inference profile 자동 해석, thinking 모드(Claude 4.7+는 adaptive + `effort`, 이전 모델은 `budget_tokens`), 1M 컨텍스트, prompt 캐싱, capability 테이블 |
 | **Neptune** | `adapters/aws/neptune.py` | Gremlin over `wss://`, SigV4 IAM, 배치 upsert/삭제. 쓰기 배치는 `indexing.neptune.index_concurrency`>1이면 스레드 풀로 동시 제출(배치별 독립 `IndexingStats` → 메인 스레드 병합, 공유 변경 없음), `aws.neptune.pool_size`로 Gremlin 커넥션 풀 다중화. 기본 1=순차 |
 | **OpenSearch** | `adapters/aws/opensearch.py` | 벡터(kNN/HNSW, 기본 엔진 **faiss** — nmslib는 deprecated) + BM25, async SigV4, sync/async 클라이언트, hybrid search pipeline, alias 관리, bulk upsert/delete, 언어별 분석기(en→english, ko→nori 등) |
 | **S3** | `adapters/aws/s3_cache.py` | 파이프라인 캐시 동기화(AES256/KMS 암호화) |

--- a/docs/design.md
+++ b/docs/design.md
@@ -267,7 +267,7 @@ Per-source behavior:
 
 | Service | Module | Purpose |
 |---|---|---|
-| **Bedrock** | `adapters/aws/bedrock.py` | LLM/embedding/reranking. Automatic cross-region inference profile resolution, thinking mode, 1M context, prompt caching, capability table |
+| **Bedrock** | `adapters/aws/bedrock.py` | LLM/embedding/reranking. Automatic cross-region inference profile resolution, thinking mode (adaptive + `effort` on Claude 4.7+, `budget_tokens` on older models), 1M context, prompt caching, capability table |
 | **Neptune** | `adapters/aws/neptune.py` | Gremlin over `wss://`, SigV4 IAM, batch upsert/delete. Write batches submit concurrently via a thread pool when `indexing.neptune.index_concurrency` > 1 (per-batch independent `IndexingStats` → merged on the main thread, no shared mutation), with `aws.neptune.pool_size` multiplexing the Gremlin connection pool. Default 1 = sequential |
 | **OpenSearch** | `adapters/aws/opensearch.py` | Vector (kNN/HNSW, default engine **faiss** — nmslib is deprecated) + BM25, async SigV4, sync/async clients, hybrid search pipeline, alias management, bulk upsert/delete, per-language analyzers (en→english, ko→nori, etc.) |
 | **S3** | `adapters/aws/s3_cache.py` | Pipeline cache sync (AES256/KMS encryption) |

--- a/docs/user-guide.ko.md
+++ b/docs/user-guide.ko.md
@@ -139,6 +139,8 @@ aws:
     region_name: "ap-northeast-2" # Bedrock can live in a different region
     assumed_role_arn: null
     enable_global_profile: true   # 크로스 리전(글로벌) Bedrock 추론 프로파일 사용 — 처리량/가용성 향상
+    enable_1m_context: false      # 1M 창이 베타인 모델에서 옵트인(장문 요금 프리미엄); Claude 5는 네이티브 1M
+    effort: "high"                # 적응형 사고 모델의 추론 깊이: low | medium | high | xhigh | max
     guardrail:                    # optional Bedrock Guardrails on every LLM call
       identifier: null            # set a guardrail ID/ARN to enable
       version: "DRAFT"
@@ -174,12 +176,36 @@ aws:
 > `region_name`이 아니라 `bedrock.region_name`(LLM 호출이 전달되는 리전)에
 > 존재해야 합니다.
 
+#### 모델 선택 주의사항
+
+기본값은 추론 비중이 큰 단계에 `anthropic.claude-sonnet-5`, 경량 단계(요약·번역·
+키워드 추출)에 `anthropic.claude-haiku-4-5-...`입니다. Claude 4.7 이후 모델은 세
+가지가 다릅니다.
+
+- **추론 프로파일이 필수입니다.** `ON_DEMAND` 처리량 없이 출시되므로 순수 모델
+  ID로는 호출할 수 없고 크로스 리전 프로파일이 반드시 해석돼야 합니다.
+  `enable_global_profile: true`를 유지하고 `bedrock:ListInferenceProfiles` 권한을
+  부여하세요. 프로파일이 없으면 어댑터가 해결 방법과 함께 즉시 실패합니다.
+  특히 `ap-northeast-2`에는 Claude 5용 `global.` 프로파일만 존재하고 `apac.`은
+  없으므로, 글로벌 프로파일을 끄면 사용 경로가 없습니다.
+- **`effort`가 사고 토큰 예산을 대체합니다.** 이 모델들에서는
+  `thinking_budget_tokens`가 무시됩니다(기존 `budget_tokens` 형식은 400으로
+  거부됨). 대신 `bedrock.effort`를 설정하세요. Claude Sonnet 5는 사고를 끌 수 없어
+  `--enable-thinking`이 무의미하며, 깊이는 `effort`로만 조절합니다.
+- **샘플링 파라미터가 제거됩니다.** `temperature`/`top_k`는 수용되지 않으므로
+  요청에서 자동 생략됩니다. 동작 제어는 프롬프트로 하세요.
+
+`anthropic.claude-fable-5`는 의도적으로 선택 가능한 모델에서 제외했습니다. 계정의
+데이터 보존 모드가 `provider_data_share`여야 하는데(Data Retention API로만 설정
+가능 — 콘솔 UI 없음) 대부분의 계정에서는 *"data retention mode 'default' is not
+available for this model"*로 실패하며, 단가도 Opus 티어를 넘습니다.
+
 ### 2.2 `fixing` — 잘못된 형식의 모델 출력 자동 복구
 
 ```yaml
 fixing:
   enabled: true
-  fixing_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+  fixing_model_id: "anthropic.claude-sonnet-5"
 ```
 
 구조화된 스테이지에서 LLM이 잘못된 형식의 JSON을 반환하면, 실행을 실패시키는 대신
@@ -243,7 +269,7 @@ target_language`이고 `additional_target_languages`가 비어 있으면 **no-op
 
 ```yaml
   graph_extraction:
-    extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    extraction_model_id: "anthropic.claude-sonnet-5"
     max_entities_per_chunk: 50
     max_relationships_per_chunk: 50
     entity_confidence_threshold: 0.0
@@ -280,7 +306,7 @@ target_language`이고 `additional_target_languages`가 비어 있으면 **no-op
 ```yaml
   gleaning:
     enabled: true
-    graph_refinement_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    graph_refinement_model_id: "anthropic.claude-sonnet-5"
     max_rounds: 3
     convergence_threshold: 0.8
     quality_threshold: 0.9
@@ -295,7 +321,7 @@ target_language`이고 `additional_target_languages`가 비어 있으면 **no-op
 ```yaml
   claim_extraction:
     enabled: false
-    extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    extraction_model_id: "anthropic.claude-sonnet-5"
     max_entities_per_prompt: 100
 ```
 
@@ -327,7 +353,7 @@ graph:
     auto_resolution: true
     report_generation:              # LLM-generated community summaries (used by global search)
       enabled: true
-      report_generation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+      report_generation_model_id: "anthropic.claude-sonnet-5"
       max_entities_per_report: 50
       max_report_context_tokens: 4000
 
@@ -383,10 +409,10 @@ indexing:
 ```yaml
 search:
   translation_model_id: "anthropic.claude-haiku-4-5-20251001-v1:0"
-  entity_extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
-  strategy_selection_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"   # the `auto` router
-  context_building_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
-  answer_generation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"    # the answer LLM
+  entity_extraction_model_id: "anthropic.claude-sonnet-5"
+  strategy_selection_model_id: "anthropic.claude-sonnet-5"   # the `auto` router
+  context_building_model_id: "anthropic.claude-sonnet-5"
+  answer_generation_model_id: "anthropic.claude-sonnet-5"    # the answer LLM
 
   hybrid:
     lexical_weight: 0.5
@@ -423,8 +449,18 @@ search:
     initial_top_k: 5
 
   token_manager:
-    max_context_tokens: 200000
+    max_context_tokens: null        # null => 답변 모델의 창 크기에서 자동 도출
+    context_window_headroom_ratio: 0.1
 ```
+
+> **컨텍스트 예산은 고정값이 아니라 도출값입니다.** `max_context_tokens: null`
+> (기본값)이면 검색 컨텍스트 예산을 `search.answer_generation_model_id`의 컨텍스트
+> 창에서 해당 모델의 출력 예약분과 헤드룸 비율을 뺀 값으로 계산합니다. 이렇게 해야
+> 두 값이 어긋나지 않습니다 — 하드코딩된 단일 숫자는 200K 모델의 창을 넘기거나
+> (창이 프롬프트와 답변을 **함께** 담아야 하므로) 1M 창의 대부분을 놀리게 됩니다.
+> 명시값도 존중되지만 모델이 수용 가능한 한도로 클램프되며, 그때 경고 로그가
+> 남습니다. `aws.bedrock.enable_1m_context`를 켜면 1M 창이 베타 옵트인인 모델에서
+> 도출 예산이 함께 넓어집니다.
 
 ### 2.7 `memory`, `cache`, `logging`
 
@@ -452,7 +488,7 @@ logging:
 ```yaml
 evaluation:
   outputs_directory: "outputs/evaluation"
-  evaluation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+  evaluation_model_id: "anthropic.claude-sonnet-5"
   enabled_evaluators:
     - langchain
     - ragas

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -137,6 +137,8 @@ aws:
     region_name: "ap-northeast-2" # Bedrock can live in a different region
     assumed_role_arn: null
     enable_global_profile: true   # use cross-region (global) Bedrock inference profiles for higher throughput/availability
+    enable_1m_context: false      # opt into the 1M window on models where it's a beta (premium billing); Claude 5 is native 1M
+    effort: "high"                # reasoning depth for adaptive-thinking models: low | medium | high | xhigh | max
     guardrail:                    # optional Bedrock Guardrails on every LLM call
       identifier: null            # set a guardrail ID/ARN to enable
       version: "DRAFT"
@@ -172,12 +174,37 @@ aws:
 > Guardrail must exist in `bedrock.region_name` (the region LLM calls go to),
 > not necessarily `region_name`.
 
+#### Model selection notes
+
+Defaults are `anthropic.claude-sonnet-5` for reasoning-heavy stages and
+`anthropic.claude-haiku-4-5-...` for light ones (summarization, translation,
+keyword extraction). Three things differ for Claude 4.7-and-later models:
+
+- **Inference profiles are mandatory.** They ship without `ON_DEMAND`
+  throughput, so the bare model id is not invocable — a cross-region profile
+  must resolve. Keep `enable_global_profile: true` and grant
+  `bedrock:ListInferenceProfiles`; the adapter fails fast with the remedy if no
+  profile resolves. Note that in `ap-northeast-2` only `global.` profiles exist
+  for Claude 5 (no `apac.`), so disabling the global profile leaves no path.
+- **`effort` replaces the thinking token budget.** `thinking_budget_tokens` is
+  ignored for these models (the old `budget_tokens` request shape is rejected
+  with a 400); set `bedrock.effort` instead. Claude Sonnet 5 always thinks, so
+  `--enable-thinking` is a no-op for it — depth is `effort` only.
+- **Sampling parameters are dropped.** `temperature`/`top_k` are not accepted
+  and are omitted from requests automatically; steer behaviour by prompting.
+
+`anthropic.claude-fable-5` is intentionally not among the selectable models: it
+requires the account's data-retention mode to be `provider_data_share` (Data
+Retention API only — no console UI), so it would fail on most accounts with
+*"data retention mode 'default' is not available for this model"*, and its
+pricing exceeds the Opus tier.
+
 ### 2.2 `fixing` — auto-repair malformed model output
 
 ```yaml
 fixing:
   enabled: true
-  fixing_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+  fixing_model_id: "anthropic.claude-sonnet-5"
 ```
 
 When an LLM returns malformed JSON for a structured stage, this re-asks a model
@@ -240,7 +267,7 @@ most impactful domain-adaptation knob (see §9). Each item is
 
 ```yaml
   graph_extraction:
-    extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    extraction_model_id: "anthropic.claude-sonnet-5"
     max_entities_per_chunk: 50
     max_relationships_per_chunk: 50
     entity_confidence_threshold: 0.0
@@ -279,7 +306,7 @@ missed on the first pass (quality vs. cost trade-off).
 ```yaml
   gleaning:
     enabled: true
-    graph_refinement_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    graph_refinement_model_id: "anthropic.claude-sonnet-5"
     max_rounds: 3
     convergence_threshold: 0.8
     quality_threshold: 0.9
@@ -294,7 +321,7 @@ When ON, `local` search injects matching claims (MS GraphRAG covariates) and
 ```yaml
   claim_extraction:
     enabled: false
-    extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    extraction_model_id: "anthropic.claude-sonnet-5"
     max_entities_per_prompt: 100
 ```
 
@@ -326,7 +353,7 @@ graph:
     auto_resolution: true
     report_generation:              # LLM-generated community summaries (used by global search)
       enabled: true
-      report_generation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+      report_generation_model_id: "anthropic.claude-sonnet-5"
       max_entities_per_report: 50
       max_report_context_tokens: 4000
 
@@ -382,10 +409,10 @@ indexing:
 ```yaml
 search:
   translation_model_id: "anthropic.claude-haiku-4-5-20251001-v1:0"
-  entity_extraction_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
-  strategy_selection_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"   # the `auto` router
-  context_building_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
-  answer_generation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"    # the answer LLM
+  entity_extraction_model_id: "anthropic.claude-sonnet-5"
+  strategy_selection_model_id: "anthropic.claude-sonnet-5"   # the `auto` router
+  context_building_model_id: "anthropic.claude-sonnet-5"
+  answer_generation_model_id: "anthropic.claude-sonnet-5"    # the answer LLM
 
   hybrid:
     lexical_weight: 0.5
@@ -422,8 +449,20 @@ search:
     initial_top_k: 5
 
   token_manager:
-    max_context_tokens: 200000
+    max_context_tokens: null        # null => derive from the answer model's window
+    context_window_headroom_ratio: 0.1
 ```
+
+> **Context budget is derived, not fixed.** With `max_context_tokens: null`
+> (the default) the retrieval context budget is computed from
+> `search.answer_generation_model_id`'s own context window, minus that model's
+> output reservation and the headroom ratio. This keeps the two in agreement: a
+> single hardcoded number either overflows a 200K model's window (the window
+> must hold the prompt *and* the answer) or leaves most of a 1M window unused.
+> An explicit value is still honoured, but is clamped to what the model can
+> accept — a warning names the clamp when that happens. Enabling
+> `aws.bedrock.enable_1m_context` widens the derived budget on models whose 1M
+> window is a beta opt-in.
 
 ### 2.7 `memory`, `cache`, `logging`
 
@@ -451,7 +490,7 @@ logging:
 ```yaml
 evaluation:
   outputs_directory: "outputs/evaluation"
-  evaluation_model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+  evaluation_model_id: "anthropic.claude-sonnet-5"
   enabled_evaluators:
     - langchain
     - ragas

--- a/tests/unit/test_bedrock_capabilities.py
+++ b/tests/unit/test_bedrock_capabilities.py
@@ -29,7 +29,7 @@ from unified_kg_rag.domain.models import (
     EmbeddingModelId,
     LanguageModelId,
 )
-from unified_kg_rag.shared import EmbeddingModelError
+from unified_kg_rag.shared import EmbeddingModelError, LanguageModelError
 
 pytestmark = pytest.mark.unit
 
@@ -154,6 +154,202 @@ def test_should_enable_thinking() -> None:
     assert BedrockLanguageModelFactory._should_enable_thinking(True, thinks) is True
     assert BedrockLanguageModelFactory._should_enable_thinking(False, thinks) is False
     assert BedrockLanguageModelFactory._should_enable_thinking(True, no_think) is False
+
+
+def test_should_enable_thinking_for_adaptive_only_model() -> None:
+    # Adaptive-thinking models think by default (Sonnet 5 / Fable 5 reject
+    # {'type': 'disabled'} outright), and the adaptive block is what carries
+    # the effort level — so it must be emitted even without an opt-in.
+    adaptive = LanguageModelInfo(
+        context_window_size=1,
+        max_output_tokens=1,
+        supports_thinking=True,
+        adaptive_thinking_only=True,
+    )
+    assert BedrockLanguageModelFactory._should_enable_thinking(False, adaptive) is True
+
+
+# --- Claude 5 request shaping ---------------------------------------------
+
+
+def test_claude_v5_models_declare_adaptive_only_and_no_sampling() -> None:
+    factory = _lang_factory()
+    for model_id in (
+        LanguageModelId.CLAUDE_V5_SONNET,
+        LanguageModelId.CLAUDE_V5_OPUS,
+    ):
+        info = factory.get_model_info(model_id)
+        assert info is not None, model_id
+        assert info.adaptive_thinking_only is True, model_id
+        assert info.supports_sampling_params is False, model_id
+        assert info.native_1m_context_window is True, model_id
+        assert info.context_window_size == 1000000, model_id
+        assert info.max_output_tokens == 128000, model_id
+
+
+def test_thinking_config_adaptive_puts_effort_outside_thinking() -> None:
+    # Nesting 'effort' inside 'thinking' is a ValidationException on Bedrock;
+    # it belongs in a sibling 'output_config' object.
+    factory = _lang_factory()
+    info = factory.get_model_info(LanguageModelId.CLAUDE_V5_SONNET)
+    assert info is not None
+    out = factory._build_thinking_config(info)
+    assert out["thinking"] == {"type": "adaptive"}
+    assert out["output_config"] == {"effort": "high"}
+    assert "budget_tokens" not in out["thinking"]
+    assert "effort" not in out["thinking"]
+
+
+def test_thinking_config_legacy_model_keeps_budget_tokens() -> None:
+    factory = _lang_factory()
+    info = factory.get_model_info(LanguageModelId.CLAUDE_V4_5_SONNET)
+    assert info is not None
+    out = factory._build_thinking_config(info, thinking_budget_tokens=4096)
+    assert out == {"thinking": {"type": "enabled", "budget_tokens": 4096}}
+    assert "output_config" not in out
+
+
+def test_thinking_config_effort_from_config_and_override() -> None:
+    config = Config()
+    config.aws.bedrock.effort = "low"
+    factory = _lang_factory(config)
+    info = factory.get_model_info(LanguageModelId.CLAUDE_V5_OPUS)
+    assert info is not None
+    assert factory._build_thinking_config(info)["output_config"] == {"effort": "low"}
+    # A per-call override wins over the config default.
+    assert factory._build_thinking_config(info, effort="max")["output_config"] == {
+        "effort": "max"
+    }
+
+
+def test_thinking_config_rejects_invalid_effort() -> None:
+    factory = _lang_factory()
+    info = factory.get_model_info(LanguageModelId.CLAUDE_V5_SONNET)
+    assert info is not None
+    with pytest.raises(LanguageModelError, match="Invalid effort level"):
+        factory._build_thinking_config(info, effort="ludicrous")
+
+
+def test_base_config_omits_top_k_for_claude_v5() -> None:
+    factory = _lang_factory()
+    v5 = factory.get_model_info(LanguageModelId.CLAUDE_V5_SONNET)
+    legacy = factory.get_model_info(LanguageModelId.CLAUDE_V4_5_SONNET)
+    assert v5 is not None and legacy is not None
+    v5_cfg = factory._build_base_config("m", False, v5)
+    assert "top_k" not in v5_cfg["model_kwargs"]
+    legacy_cfg = factory._build_base_config("m", False, legacy)
+    assert legacy_cfg["model_kwargs"]["top_k"] == factory.DEFAULT_TOP_K
+
+
+def test_model_config_omits_temperature_for_claude_v5() -> None:
+    factory = _lang_factory()
+    info = factory.get_model_info(LanguageModelId.CLAUDE_V5_SONNET)
+    assert info is not None
+    cfg = factory._build_model_config(info, "apac.anthropic.claude-sonnet-5", True)
+    assert "temperature" not in cfg
+    assert "top_k" not in cfg
+    # Adaptive thinking is emitted even without enable_thinking (always-on).
+    fields = cfg["additional_model_request_fields"]
+    assert fields["thinking"] == {"type": "adaptive"}
+    assert fields["output_config"] == {"effort": "high"}
+
+
+def _config_with_1m(enabled: bool) -> Config:
+    config = Config()
+    config.aws.bedrock.enable_1m_context = enabled
+    return config
+
+
+def test_model_config_skips_1m_beta_header_for_claude_v5() -> None:
+    # 1M is the default window on Claude 5; the beta opt-in header older
+    # models need must not be sent even when the opt-in is on.
+    factory = _lang_factory(_config_with_1m(True))
+    info = factory.get_model_info(LanguageModelId.CLAUDE_V5_SONNET)
+    assert info is not None
+    cfg = factory._build_model_config(info, "apac.anthropic.claude-sonnet-5", True)
+    assert "anthropic_beta" not in cfg.get("additional_model_request_fields", {})
+
+
+def test_model_config_1m_beta_header_follows_config_flag() -> None:
+    # The 1M opt-in is a config flag: previously it was a kwarg no caller ever
+    # passed, so the header could never be sent at all.
+    legacy_id = "apac.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    on = _lang_factory(_config_with_1m(True))
+    info = on.get_model_info(LanguageModelId.CLAUDE_V4_5_SONNET)
+    assert info is not None
+    cfg = on._build_model_config(info, legacy_id, True)
+    assert cfg["additional_model_request_fields"]["anthropic_beta"] == [
+        "context-1m-2025-08-07"
+    ]
+
+    off = _lang_factory(_config_with_1m(False))
+    cfg_off = off._build_model_config(info, legacy_id, True)
+    assert "anthropic_beta" not in cfg_off.get("additional_model_request_fields", {})
+
+
+def test_effective_context_window_tracks_1m_opt_in() -> None:
+    factory = _lang_factory()
+    beta = factory.get_model_info(LanguageModelId.CLAUDE_V4_5_SONNET)
+    native = factory.get_model_info(LanguageModelId.CLAUDE_V5_SONNET)
+    plain = factory.get_model_info(LanguageModelId.CLAUDE_V4_5_HAIKU)
+    assert beta is not None and native is not None and plain is not None
+    # Beta-gated: baseline until the opt-in is on.
+    assert beta.effective_context_window(False) == 200000
+    assert beta.effective_context_window(True) == 1000000
+    # Native 1M is already the declared window.
+    assert native.effective_context_window(False) == 1000000
+    # No 1M support: the flag must not inflate the window.
+    assert plain.effective_context_window(True) == 200000
+
+
+def test_model_config_keeps_temperature_for_legacy_model() -> None:
+    factory = _lang_factory()
+    info = factory.get_model_info(LanguageModelId.CLAUDE_V4_5_SONNET)
+    assert info is not None
+    cfg = factory._build_model_config(
+        info, "apac.anthropic.claude-sonnet-4-5-20250929-v1:0", True
+    )
+    assert cfg["temperature"] == factory.DEFAULT_TEMPERATURE
+
+
+def test_build_cross_region_model_id_handles_suffixless_v5_id() -> None:
+    # Claude 5 ids carry no date/revision suffix; prefixing must still work.
+    out = BedrockCrossRegionModelHelper._build_cross_region_model_id(
+        LanguageModelId.CLAUDE_V5_SONNET, "ap-northeast-2"
+    )
+    assert out == "apac.anthropic.claude-sonnet-5"
+
+
+def test_get_model_raises_when_profile_only_model_has_no_profile(mocker) -> None:
+    # Claude 5 is INFERENCE_PROFILE-only: the bare id is not invocable. When
+    # resolution falls back to it, fail with the remedy rather than letting an
+    # opaque Bedrock error surface on the first call.
+    factory = _lang_factory()
+    mocker.patch.object(
+        bedrock_mod.BedrockCrossRegionModelHelper,
+        "get_cross_region_model_id",
+        return_value=LanguageModelId.CLAUDE_V5_SONNET.value,
+    )
+    with pytest.raises(LanguageModelError, match="cross-region inference profile"):
+        factory.get_model(LanguageModelId.CLAUDE_V5_SONNET)
+
+
+def test_get_model_allows_on_demand_model_without_profile(mocker) -> None:
+    # Legacy ON_DEMAND models must still work when no profile resolves.
+    factory = _lang_factory()
+    mocker.patch.object(
+        bedrock_mod.BedrockCrossRegionModelHelper,
+        "get_cross_region_model_id",
+        return_value=LanguageModelId.CLAUDE_V3_HAIKU.value,
+    )
+    sentinel = object()
+
+    class _FakeChatBedrock:  # needs __name__ for the debug log
+        def __new__(cls, **kwargs: Any) -> Any:
+            return sentinel
+
+    mocker.patch.object(bedrock_mod, "ChatBedrock", _FakeChatBedrock)
+    assert factory.get_model(LanguageModelId.CLAUDE_V3_HAIKU) is sentinel
 
 
 def test_should_enable_performance_optimization() -> None:

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -55,7 +55,14 @@ def test_count_tokens_degrades_to_script_aware_estimate(mocker) -> None:
 
 
 class FakeBedrockClient:
-    """Returns a fixed token count proportional to character length."""
+    """Returns a fixed token count proportional to character length.
+
+    Mirrors the real CountTokens wire shape: the payload nests under ``input``
+    and the response key is ``inputTokens``. An earlier fake accepted a
+    top-level ``converse=`` and returned ``totalTokens``, which matched the
+    (wrong) call the adapter made — so the tests passed while every real call
+    failed and silently degraded to the estimate.
+    """
 
     def __init__(self, chars_per_token: int = 4) -> None:
         self.chars_per_token = chars_per_token
@@ -63,8 +70,12 @@ class FakeBedrockClient:
 
     def count_tokens(self, **kwargs) -> dict:
         self.calls += 1
-        text = kwargs["converse"]["messages"][0]["content"][0]["text"]
-        return {"totalTokens": max(1, len(text) // self.chars_per_token)}
+        if "converse" in kwargs:
+            raise AssertionError(
+                "'converse' must be nested under 'input', not passed top-level"
+            )
+        text = kwargs["input"]["converse"]["messages"][0]["content"][0]["text"]
+        return {"inputTokens": max(1, len(text) // self.chars_per_token)}
 
 
 class FailingClient:
@@ -96,6 +107,26 @@ def test_degrades_to_word_count_on_api_failure() -> None:
     counter = BedrockTokenCounter("model", FailingClient())
     # No exception propagates; degrades to whitespace word count.
     assert counter.count_tokens("one two three four") == 4
+
+
+def test_request_uses_documented_count_tokens_wire_shape() -> None:
+    # Regression: the request must nest 'converse' under 'input' and read
+    # 'inputTokens' back. Getting either wrong is invisible at runtime — the
+    # failure is swallowed by the estimate fallback — so pin the shape here.
+    captured: dict[str, object] = {}
+
+    class _Recorder:
+        def count_tokens(self, **kwargs: object) -> dict:
+            captured.update(kwargs)
+            return {"inputTokens": 7}
+
+    counter = BedrockTokenCounter("model-x", _Recorder())
+    assert counter.count_tokens("hello") == 7
+    assert captured["modelId"] == "model-x"
+    assert "converse" not in captured
+    payload = captured["input"]
+    assert isinstance(payload, dict)
+    assert payload["converse"]["messages"][0]["content"][0]["text"] == "hello"
 
 
 def test_truncate_converges_under_limit() -> None:

--- a/tests/unit/test_token_manager.py
+++ b/tests/unit/test_token_manager.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from unified_kg_rag.adapters.aws.bedrock import get_language_model_info
 from unified_kg_rag.adapters.retrieval import token_manager as tm_module
 from unified_kg_rag.adapters.retrieval.token_manager import (
     ContextSection,
@@ -21,15 +22,24 @@ from unified_kg_rag.adapters.retrieval.token_manager import (
     SectionType,
     TokenManager,
 )
-from unified_kg_rag.domain.models import Config, RetrievalResult
+from unified_kg_rag.domain.models import Config, LanguageModelId, RetrievalResult
 from unified_kg_rag.domain.models.config import ContextTypeBudgetConfig
 
 pytestmark = pytest.mark.unit
 
 
-def _make_manager(mocker, max_context_tokens: int = 200000) -> TokenManager:
+def _make_manager(
+    mocker,
+    max_context_tokens: int | None = None,
+    answer_model_id: LanguageModelId | None = None,
+    enable_1m_context: bool = False,
+) -> TokenManager:
     """Build a TokenManager with Bedrock/boto wiring stubbed and a deterministic
-    word-count token counter (1 token per whitespace-delimited word)."""
+    word-count token counter (1 token per whitespace-delimited word).
+
+    ``max_context_tokens=None`` (the default) exercises the production path where
+    the budget is derived from the answer model's context window.
+    """
     mocker.patch.object(tm_module, "boto3")
     mocker.patch.object(tm_module, "get_assumed_role_boto_session")
 
@@ -39,6 +49,9 @@ def _make_manager(mocker, max_context_tokens: int = 200000) -> TokenManager:
 
     config = Config()
     config.search.token_manager.max_context_tokens = max_context_tokens
+    config.aws.bedrock.enable_1m_context = enable_1m_context
+    if answer_model_id is not None:
+        config.search.answer_generation_model_id = answer_model_id
     return TokenManager(config)
 
 
@@ -46,6 +59,74 @@ def _r(content: str, score: float, retriever_type: str, source: str) -> Retrieva
     return RetrievalResult(
         content=content, score=score, retriever_type=retriever_type, source=source
     )
+
+
+class TestContextBudgetDerivation:
+    """The prompt budget must track the answer model's real context window.
+
+    A hardcoded budget silently overflows a smaller model's window (the old
+    default of 200000 left no room for a 200K model's 64K output reservation)
+    and wastes a larger one.
+    """
+
+    def test_derives_from_model_window_when_unset(self, mocker) -> None:
+        # Sonnet 5: 1M window - 128K output, less 10% headroom.
+        mgr = _make_manager(mocker, answer_model_id=LanguageModelId.CLAUDE_V5_SONNET)
+        assert mgr._max_context_tokens == int((1000000 - 128000) * 0.9)
+
+    def test_smaller_window_gets_smaller_budget(self, mocker) -> None:
+        mgr = _make_manager(mocker, answer_model_id=LanguageModelId.CLAUDE_V4_5_SONNET)
+        assert mgr._max_context_tokens == int((200000 - 64000) * 0.9)
+
+    def test_derived_budget_leaves_room_for_output(self, mocker) -> None:
+        # The invariant the old hardcoded 200000 violated on every 200K model.
+        for model_id in (
+            LanguageModelId.CLAUDE_V4_5_SONNET,
+            LanguageModelId.CLAUDE_V4_5_HAIKU,
+            LanguageModelId.CLAUDE_V3_HAIKU,
+            LanguageModelId.CLAUDE_V5_SONNET,
+        ):
+            mgr = _make_manager(mocker, answer_model_id=model_id)
+            info = get_language_model_info(model_id)
+            assert info is not None
+            assert (
+                mgr._max_context_tokens + info.max_output_tokens
+                <= info.context_window_size
+            ), model_id
+
+    def test_explicit_budget_over_window_is_clamped(self, mocker) -> None:
+        mgr = _make_manager(
+            mocker,
+            max_context_tokens=200000,
+            answer_model_id=LanguageModelId.CLAUDE_V4_5_SONNET,
+        )
+        assert mgr._max_context_tokens == int((200000 - 64000) * 0.9)
+
+    def test_explicit_budget_within_window_is_honoured(self, mocker) -> None:
+        mgr = _make_manager(
+            mocker,
+            max_context_tokens=50000,
+            answer_model_id=LanguageModelId.CLAUDE_V5_SONNET,
+        )
+        assert mgr._max_context_tokens == 50000
+
+    def test_1m_opt_in_widens_budget_for_beta_model(self, mocker) -> None:
+        narrow = _make_manager(
+            mocker, answer_model_id=LanguageModelId.CLAUDE_V4_5_SONNET
+        )
+        wide = _make_manager(
+            mocker,
+            answer_model_id=LanguageModelId.CLAUDE_V4_5_SONNET,
+            enable_1m_context=True,
+        )
+        assert wide._max_context_tokens > narrow._max_context_tokens
+        assert wide._max_context_tokens == int((1000000 - 64000) * 0.9)
+
+    def test_caller_max_tokens_cannot_exceed_model_budget(self, mocker) -> None:
+        mgr = _make_manager(mocker, answer_model_id=LanguageModelId.CLAUDE_V4_5_SONNET)
+        huge = [_r(" ".join(["w"] * 500), 0.9, "text", f"s{i}") for i in range(200)]
+        out = mgr.optimize_context(huge, query="q", max_tokens=10_000_000)
+        assert out.total_tokens <= mgr._max_context_tokens
 
 
 class TestCountTokens:

--- a/unified_kg_rag/adapters/aws/bedrock.py
+++ b/unified_kg_rag/adapters/aws/bedrock.py
@@ -70,8 +70,62 @@ class LanguageModelInfo(BaseModel):
     )
     supports_1m_context_window: bool = Field(
         default=False,
-        description="Whether the model supports 1M context window.",
+        description=(
+            "Whether the model can reach a 1M context window via the "
+            "'context-1m-2025-08-07' beta opt-in. Requires "
+            "aws.bedrock.enable_1m_context; without it the effective window is "
+            "context_window_size. Use native_1m_context_window for models where "
+            "1M needs no opt-in."
+        ),
     )
+    adaptive_thinking_only: bool = Field(
+        default=False,
+        description=(
+            "Whether the model accepts only adaptive thinking. Claude 4.7+ rejects "
+            "the manual {'type': 'enabled', 'budget_tokens': N} shape with a 400; "
+            "thinking depth is steered by 'effort' instead of a token budget. "
+            "These models also think by default — Sonnet 5 / Fable 5 cannot be "
+            "turned off at all — so their requests always carry the adaptive "
+            "config, which is what lets 'effort' through."
+        ),
+    )
+    supports_sampling_params: bool = Field(
+        default=True,
+        description=(
+            "Whether temperature/top_p/top_k are accepted. Claude 4.7+ removed "
+            "them and returns a 400 for non-default values; the documented "
+            "migration path is to omit them and steer behaviour by prompting."
+        ),
+    )
+    native_1m_context_window: bool = Field(
+        default=False,
+        description=(
+            "Whether the 1M context window is the default and needs no beta "
+            "opt-in header. True for Claude 5, where 1M is both default and max."
+        ),
+    )
+    requires_inference_profile: bool = Field(
+        default=False,
+        description=(
+            "Whether the model is INFERENCE_PROFILE-only (no ON_DEMAND). Newer "
+            "Claude models ship without on-demand throughput, so invoking the "
+            "bare model id fails — a cross-region profile must resolve."
+        ),
+    )
+
+    BETA_1M_CONTEXT_WINDOW_SIZE: ClassVar[int] = 1000000
+
+    def effective_context_window(self, enable_1m_context: bool = False) -> int:
+        """Context window the model will actually honour for a request.
+
+        ``context_window_size`` is the baseline. Models that reach 1M only
+        through the beta opt-in report that baseline until the opt-in is on, so
+        a caller sizing a token budget must ask here rather than reading the
+        field directly — otherwise the budget ignores an enabled 1M window.
+        """
+        if enable_1m_context and self.supports_1m_context_window:
+            return max(self.context_window_size, self.BETA_1M_CONTEXT_WINDOW_SIZE)
+        return self.context_window_size
 
 
 class RerankModelInfo(BaseModel):
@@ -120,6 +174,38 @@ _EMBEDDING_MODEL_INFO: dict[EmbeddingModelId, EmbeddingModelInfo] = {
 }
 
 _LANGUAGE_MODEL_INFO: dict[LanguageModelId, LanguageModelInfo] = {
+    # --- Claude 5 -------------------------------------------------------
+    # 1M context is the default (and the maximum), so no beta opt-in header.
+    # Both take adaptive thinking only and reject sampling parameters.
+    LanguageModelId.CLAUDE_V5_SONNET: LanguageModelInfo(
+        context_window_size=1000000,
+        max_output_tokens=128000,
+        supports_prompt_caching=True,
+        supports_thinking=True,
+        supports_1m_context_window=True,
+        native_1m_context_window=True,
+        adaptive_thinking_only=True,
+        supports_sampling_params=False,
+        requires_inference_profile=True,
+    ),
+    LanguageModelId.CLAUDE_V5_OPUS: LanguageModelInfo(
+        context_window_size=1000000,
+        max_output_tokens=128000,
+        supports_prompt_caching=True,
+        supports_thinking=True,
+        supports_1m_context_window=True,
+        native_1m_context_window=True,
+        adaptive_thinking_only=True,
+        # Opus 5 also accepts {'type': 'disabled'}, but only at effort <= high.
+        # We always send adaptive, so that cap never applies.
+        supports_sampling_params=False,
+        requires_inference_profile=True,
+    ),
+    # Claude Fable 5 is deliberately NOT offered: it requires the account's
+    # data-retention mode to be 'provider_data_share' (Data Retention API only,
+    # no console UI), so a selectable entry would fail for most accounts with
+    # "data retention mode 'default' is not available for this model". Its
+    # pricing also exceeds the Opus tier.
     LanguageModelId.CLAUDE_V3_HAIKU: LanguageModelInfo(
         context_window_size=200000,
         max_output_tokens=4096,
@@ -204,6 +290,16 @@ _RERANK_MODEL_INFO: dict[str, RerankModelInfo] = {
     ),
     # NOTE: add new models here
 }
+
+
+def get_language_model_info(model_id: LanguageModelId) -> LanguageModelInfo | None:
+    """Capability record for a language model, or None if unregistered.
+
+    Public read accessor for the capability table so callers that need a
+    model's limits without constructing a factory (which opens a boto client)
+    don't reach into the private dict.
+    """
+    return _LANGUAGE_MODEL_INFO.get(model_id)
 
 
 ModelIdT = TypeVar("ModelIdT")
@@ -533,6 +629,12 @@ class BedrockLanguageModelFactory(
     DEFAULT_TOP_K: ClassVar[int] = 50
     DEFAULT_THINKING_BUDGET_TOKENS: ClassVar[int] = 2048
     DEFAULT_LATENCY_MODE: ClassVar[str] = "normal"
+    # Effort replaces budget_tokens on adaptive-thinking models. "high" is the
+    # Bedrock default; "medium" trades some depth for tokens and latency.
+    DEFAULT_EFFORT: ClassVar[str] = "high"
+    VALID_EFFORTS: ClassVar[frozenset[str]] = frozenset(
+        {"low", "medium", "high", "xhigh", "max"}
+    )
 
     def _get_boto_service_name(self) -> str:
         return "bedrock-runtime"
@@ -558,6 +660,18 @@ class BedrockLanguageModelFactory(
             enable_global_profile=self.config.aws.bedrock.enable_global_profile,
         )
         is_cross_region = resolved_model_id != model_id.value
+        if model_info.requires_inference_profile and not is_cross_region:
+            # Claude 4.6+ ships INFERENCE_PROFILE-only (no ON_DEMAND throughput),
+            # so the bare model id is not invocable. Resolution silently falls
+            # back to it, which would surface later as an opaque Bedrock error —
+            # fail here with the actual remedy instead.
+            raise LanguageModelError(
+                f"Model '{model_id.value}' is only available through a "
+                f"cross-region inference profile, but none resolved in region "
+                f"'{self.region_name}'. Enable aws.bedrock.enable_global_profile, "
+                f"grant bedrock:ListInferenceProfiles, or choose a region where "
+                f"a profile for this model exists."
+            )
         model_config = self._build_model_config(
             model_info, resolved_model_id, is_cross_region, **kwargs
         )
@@ -578,28 +692,46 @@ class BedrockLanguageModelFactory(
         **kwargs: Any,
     ) -> dict[str, Any]:
         enable_thinking = kwargs.get("enable_thinking", False)
-        supports_1m_context_window = kwargs.get("supports_1m_context_window", False)
-        temperature = kwargs.get("temperature", self.DEFAULT_TEMPERATURE)
-        final_temperature = (
-            1.0
-            if self._should_enable_thinking(enable_thinking, model_info)
-            else temperature
-        )
-        if final_temperature != temperature:
-            logger.debug("Adjusting temperature to 1.0 for thinking mode")
         final_max_tokens = self._validate_max_tokens(
             kwargs.get("max_tokens"), model_info
         )
-        config = self._build_base_config(resolved_model_id, is_cross_region, **kwargs)
-        if is_cross_region:
-            config.update(
-                {"max_tokens": final_max_tokens, "temperature": final_temperature}
+        config = self._build_base_config(
+            resolved_model_id, is_cross_region, model_info, **kwargs
+        )
+        token_params: dict[str, Any] = {"max_tokens": final_max_tokens}
+        if model_info.supports_sampling_params:
+            temperature = kwargs.get("temperature", self.DEFAULT_TEMPERATURE)
+            # Thinking models sample at a fixed temperature of 1.0.
+            final_temperature = (
+                1.0
+                if self._should_enable_thinking(enable_thinking, model_info)
+                else temperature
             )
+            if final_temperature != temperature:
+                logger.debug("Adjusting temperature to 1.0 for thinking mode")
+            token_params["temperature"] = final_temperature
         else:
-            config["model_kwargs"].update(
-                {"max_tokens": final_max_tokens, "temperature": final_temperature}
+            # Claude 4.7+ removed temperature/top_p/top_k; sending any of them
+            # returns a 400. Behaviour is steered by prompting and 'effort'.
+            logger.debug(
+                "Omitting sampling parameters for '%s' (unsupported by model)",
+                resolved_model_id,
             )
-        if supports_1m_context_window and model_info.supports_1m_context_window:
+        if is_cross_region:
+            config.update(token_params)
+        else:
+            config["model_kwargs"].update(token_params)
+        if model_info.native_1m_context_window:
+            # 1M is the default window on Claude 5 — the beta opt-in header
+            # that older models need is unnecessary (and misleading) here.
+            logger.debug(
+                "Model '%s' has a native 1M context window; skipping beta header",
+                resolved_model_id,
+            )
+        elif (
+            self.config.aws.bedrock.enable_1m_context
+            and model_info.supports_1m_context_window
+        ):
             if is_cross_region:
                 config.setdefault("additional_model_request_fields", {}).update(
                     {"anthropic_beta": ["context-1m-2025-08-07"]}
@@ -613,7 +745,11 @@ class BedrockLanguageModelFactory(
         return config
 
     def _build_base_config(
-        self, resolved_model_id: str, is_cross_region: bool, **kwargs: Any
+        self,
+        resolved_model_id: str,
+        is_cross_region: bool,
+        model_info: LanguageModelInfo,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         config = {
             "model_id": resolved_model_id,
@@ -631,11 +767,14 @@ class BedrockLanguageModelFactory(
         }
         if is_cross_region:
             config.update(common_params)
-        else:
+        elif model_info.supports_sampling_params:
             config["model_kwargs"] = {
                 "top_k": kwargs.get("top_k", self.DEFAULT_TOP_K),
                 **common_params,
             }
+        else:
+            # top_k is a sampling parameter; Claude 4.7+ rejects it.
+            config["model_kwargs"] = dict(common_params)
         return config
 
     def _apply_model_features(
@@ -656,18 +795,43 @@ class BedrockLanguageModelFactory(
                 "Applied performance optimization (latency_mode='%s')", latency
             )
         if self._should_enable_thinking(enable_think, model_info):
-            budget = kwargs.get(
-                "thinking_budget_tokens", self.DEFAULT_THINKING_BUDGET_TOKENS
-            )
-            think_config = {"thinking": {"type": "enabled", "budget_tokens": budget}}
+            think_config = self._build_thinking_config(model_info, **kwargs)
             if is_cross_region:
                 config.setdefault("additional_model_request_fields", {}).update(
                     think_config
                 )
             else:
                 config.setdefault("model_kwargs", {}).update(think_config)
-            logger.debug("Applied thinking mode (budget_tokens=%d)", budget)
         self._apply_guardrail(config, is_cross_region)
+
+    def _build_thinking_config(
+        self, model_info: LanguageModelInfo, **kwargs: Any
+    ) -> dict[str, Any]:
+        """Assemble the reasoning request fields for a model.
+
+        Adaptive-thinking models (Claude 4.7+) reject the manual
+        ``{"type": "enabled", "budget_tokens": N}`` shape with a 400 and steer
+        depth via ``effort`` instead. ``effort`` must sit in its own
+        ``output_config`` object — nesting it inside ``thinking`` raises a
+        ``ValidationException``.
+        """
+        if not model_info.adaptive_thinking_only:
+            budget = kwargs.get(
+                "thinking_budget_tokens", self.DEFAULT_THINKING_BUDGET_TOKENS
+            )
+            logger.debug("Applied extended thinking (budget_tokens=%d)", budget)
+            return {"thinking": {"type": "enabled", "budget_tokens": budget}}
+        effort = kwargs.get("effort") or self.config.aws.bedrock.effort
+        if effort not in self.VALID_EFFORTS:
+            raise LanguageModelError(
+                f"Invalid effort level '{effort}'. "
+                f"Valid levels: {sorted(self.VALID_EFFORTS)}"
+            )
+        logger.debug("Applied adaptive thinking (effort='%s')", effort)
+        return {
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": effort},
+        }
 
     def _apply_guardrail(self, config: dict[str, Any], is_cross_region: bool) -> None:
         """Attach Bedrock Guardrails to the model when configured.
@@ -724,7 +888,14 @@ class BedrockLanguageModelFactory(
 
     @staticmethod
     def _should_enable_thinking(enable: bool, model_info: LanguageModelInfo) -> bool:
-        return enable and model_info.supports_thinking
+        if not model_info.supports_thinking:
+            return False
+        # Adaptive-thinking models think by default (and Sonnet 5 / Fable 5
+        # reject {'type': 'disabled'} outright), so their requests always carry
+        # the adaptive config regardless of the caller's flag — that block is
+        # also what carries the configured effort level, which would otherwise
+        # be silently dropped.
+        return enable or model_info.adaptive_thinking_only
 
 
 class BedrockRerankWrapper(BaseBedrockWrapper, BedrockRerank):

--- a/unified_kg_rag/adapters/aws/token_counter.py
+++ b/unified_kg_rag/adapters/aws/token_counter.py
@@ -36,7 +36,9 @@ def estimate_token_count(text: str) -> int:
     """Script-aware token-count estimate for the API-unavailable fallback.
 
     Bedrock's CountTokens API does not support embedding models, so embedding
-    truncation always lands on this estimate. A flat ~4-chars-per-token estimate
+    truncation always lands on this estimate. Nor does it support every language
+    model: Claude 5 (and Opus 4.8) reject it on ``bedrock-runtime``, so context
+    budgeting for those models lands here too. A flat ~4-chars-per-token estimate
     under-counts space-less dense scripts (CJK, kana, Hangul) ~4x — a whole
     Korean/Japanese sentence is few "words" and few chars-over-4 but many tokens
     — which let over-limit chunks slip past truncation and fail the embedding
@@ -140,15 +142,21 @@ class BedrockTokenCounter:
         return truncated, final_count
 
     def _call_bedrock_count_tokens(self, text: str) -> int:
+        # The request nests the payload under `input` and the response returns
+        # `inputTokens`. A top-level `converse=` raises ParamValidationError and
+        # `totalTokens` raises KeyError — both were silently swallowed by the
+        # estimate fallback, so every count degraded rather than failing loudly.
         response = self._client.count_tokens(
             modelId=self.model_id,
-            converse={
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": [{"text": text}],
-                    }
-                ]
+            input={
+                "converse": {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [{"text": text}],
+                        }
+                    ]
+                }
             },
         )
-        return int(response["totalTokens"])
+        return int(response["inputTokens"])

--- a/unified_kg_rag/adapters/retrieval/token_manager.py
+++ b/unified_kg_rag/adapters/retrieval/token_manager.py
@@ -7,9 +7,12 @@ import boto3
 from botocore.config import Config as BotoConfig
 from pydantic import BaseModel, Field
 
-from unified_kg_rag.adapters.aws.bedrock import get_assumed_role_boto_session
+from unified_kg_rag.adapters.aws.bedrock import (
+    get_assumed_role_boto_session,
+    get_language_model_info,
+)
 from unified_kg_rag.adapters.aws.token_counter import BedrockTokenCounter
-from unified_kg_rag.domain.models import Config, RetrievalResult
+from unified_kg_rag.domain.models import Config, LanguageModelId, RetrievalResult
 from unified_kg_rag.domain.retrieval.mixins import MetricsMixin
 from unified_kg_rag.shared import get_logger
 
@@ -64,6 +67,11 @@ class OptimizedContext(BaseModel):
 
 
 class TokenManager(MetricsMixin):
+    # Used only when the answer model has no capability record (custom backend)
+    # and no explicit budget is configured. Sized for the smallest window this
+    # package targets (200K) so it can never overflow a known model.
+    FALLBACK_MAX_CONTEXT_TOKENS: ClassVar[int] = 120000
+    MIN_DERIVED_CONTEXT_TOKENS: ClassVar[int] = 1024
     PRIORITY_MULTIPLIERS: ClassVar[dict[SectionType, float]] = {
         SectionType.TEXT: 1.3,
         SectionType.ENTITY: 1.2,
@@ -95,12 +103,70 @@ class TokenManager(MetricsMixin):
             ),
         )
 
-        model_id = config.search.answer_generation_model_id.value
+        answer_model_id = config.search.answer_generation_model_id
+        self._enable_1m_context = config.aws.bedrock.enable_1m_context
         self._token_counter = BedrockTokenCounter(
-            model_id=model_id,
+            model_id=answer_model_id.value,
             client=bedrock_client,
             cache_maxsize=self.config.token_count_cache_size,
         )
+        self._max_context_tokens = self._resolve_max_context_tokens(answer_model_id)
+
+    def _resolve_max_context_tokens(self, answer_model_id: LanguageModelId) -> int:
+        """Size the prompt-side budget against the answer model's real window.
+
+        The context budget and the model's context window are separate settings
+        that must agree: the window has to hold the prompt *and* the generated
+        answer, so a budget of window-size leaves no room for output. Deriving it
+        from the model's own capabilities keeps the two in sync when the answer
+        model changes (a 200K model and a 1M model want very different budgets).
+        """
+        model_info = get_language_model_info(answer_model_id)
+        configured = self.config.max_context_tokens
+        if model_info is None:
+            # Unknown model (custom backend): honour the explicit value, or fall
+            # back to a conservative budget rather than guessing a window.
+            if configured is not None:
+                return configured
+            logger.warning(
+                "No capability record for answer model '%s'; using the fallback "
+                "context budget of %d tokens. Set "
+                "search.token_manager.max_context_tokens explicitly.",
+                answer_model_id.value,
+                self.FALLBACK_MAX_CONTEXT_TOKENS,
+            )
+            return self.FALLBACK_MAX_CONTEXT_TOKENS
+
+        headroom = self.config.context_window_headroom_ratio
+        window = model_info.effective_context_window(self._enable_1m_context)
+        budget_ceiling = int((window - model_info.max_output_tokens) * (1.0 - headroom))
+        # A model whose output reservation swallows its window would yield a
+        # non-positive ceiling; keep a usable floor instead of returning <= 0,
+        # which optimize_context treats as "exclude everything".
+        budget_ceiling = max(budget_ceiling, self.MIN_DERIVED_CONTEXT_TOKENS)
+
+        if configured is None:
+            logger.debug(
+                "Derived context budget of %d tokens for '%s' (window=%d, "
+                "output=%d, headroom=%.0f%%)",
+                budget_ceiling,
+                answer_model_id.value,
+                window,
+                model_info.max_output_tokens,
+                headroom * 100,
+            )
+            return budget_ceiling
+        if configured > budget_ceiling:
+            logger.warning(
+                "Configured max_context_tokens (%d) exceeds what '%s' can accept "
+                "alongside its %d-token output reservation; clamping to %d.",
+                configured,
+                answer_model_id.value,
+                model_info.max_output_tokens,
+                budget_ceiling,
+            )
+            return budget_ceiling
+        return configured
 
     def count_tokens(self, text: str) -> int:
         if not text:
@@ -114,7 +180,13 @@ class TokenManager(MetricsMixin):
         max_tokens: int | None = None,
         max_context_tokens_buffer: int = 512,
     ) -> OptimizedContext:
-        target_tokens = max_tokens or self.config.max_context_tokens
+        # A caller-supplied budget is still capped by what the answer model can
+        # accept, so a large --top-k / RAGInput.max_tokens cannot overflow it.
+        target_tokens = (
+            min(max_tokens, self._max_context_tokens)
+            if max_tokens
+            else (self._max_context_tokens)
+        )
         query_tokens = self.count_tokens(query)
         available_tokens = target_tokens - query_tokens - max_context_tokens_buffer
 

--- a/unified_kg_rag/application/cli/run_rag_chain.py
+++ b/unified_kg_rag/application/cli/run_rag_chain.py
@@ -79,7 +79,11 @@ class CommandLineInterface:
         parser.add_argument(
             "--enable-thinking",
             action="store_true",
-            help="Enable thinking mode for language model reasoning and step-by-step problem solving",
+            help=(
+                "Enable thinking mode for language model reasoning and step-by-step "
+                "problem solving. No-op for models that always think (Claude Sonnet 5, "
+                "Fable 5); tune their depth with aws.bedrock.effort in the config"
+            ),
         )
         parser.add_argument(
             "--search-strategy",

--- a/unified_kg_rag/domain/models/config.py
+++ b/unified_kg_rag/domain/models/config.py
@@ -3,7 +3,7 @@
 import math
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, SecretStr, model_validator
 
@@ -77,6 +77,11 @@ class EmbeddingModelId(str, Enum):
 
 
 class LanguageModelId(str, Enum):
+    # Claude 5 ids carry no date suffix and no ':0' revision, unlike every
+    # earlier generation. Cross-region resolution still applies the same
+    # 'us.'/'apac.'/'global.' inference-profile prefixes.
+    CLAUDE_V5_SONNET = "anthropic.claude-sonnet-5"
+    CLAUDE_V5_OPUS = "anthropic.claude-opus-5"
     CLAUDE_V3_HAIKU = "anthropic.claude-3-haiku-20240307-v1:0"
     CLAUDE_V3_SONNET = "anthropic.claude-3-sonnet-20240229-v1:0"
     CLAUDE_V3_OPUS = "anthropic.claude-3-opus-20240229-v1:0"
@@ -135,6 +140,24 @@ class BedrockConfig(BaseModel):
     )
     enable_global_profile: bool = Field(
         default=True, description="Enable global profile for Bedrock service"
+    )
+    enable_1m_context: bool = Field(
+        default=False,
+        description=(
+            "Opt into the 1M-token context window on models that support it as "
+            "a beta (Claude Sonnet 4 / 4.5, Opus 4 / 4.1 / 4.5). Off by default: "
+            "long-context requests are billed at a premium on those models. "
+            "Claude 5 has a native 1M window and ignores this flag. Enabling it "
+            "also widens the derived retrieval context budget."
+        ),
+    )
+    effort: Literal["low", "medium", "high", "xhigh", "max"] = Field(
+        default="high",
+        description=(
+            "Reasoning effort for adaptive-thinking models (Claude 4.7+), which "
+            "replaces the fixed thinking token budget. 'xhigh'/'max' are only "
+            "accepted by some models; lower levels trade depth for cost/latency."
+        ),
     )
     guardrail: GuardrailConfig = Field(
         default_factory=GuardrailConfig,
@@ -270,7 +293,7 @@ class FixingConfig(BaseModel):
         default=True, description="Enable automatic fixing of malformed model responses"
     )
     fixing_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model for output correction",
     )
 
@@ -465,7 +488,7 @@ class EntityGroundingConfig(BaseModel):
 
 class GraphExtractionConfig(BaseModel):
     extraction_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model for entity and relationship extraction",
     )
     max_entities_per_chunk: int = Field(
@@ -512,7 +535,7 @@ class GleaningConfig(BaseModel):
         default=True, description="Enable gleaning for improved extraction"
     )
     graph_refinement_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model for graph refinement",
     )
     max_rounds: int = Field(default=3, ge=1, description="Maximum gleaning rounds")
@@ -582,7 +605,7 @@ class ClaimExtractionConfig(BaseModel):
         "(DataIngestionPipeline._initialize_stages).",
     )
     extraction_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model for claim extraction",
     )
     max_entities_per_prompt: int = Field(
@@ -755,7 +778,7 @@ class ReportGenerationConfig(BaseModel):
         default=True, description="Enable automatic community report generation"
     )
     report_generation_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model for community report generation",
     )
     max_entities_per_report: int = Field(
@@ -1523,10 +1546,26 @@ class ContextTypeBudgetConfig(BaseModel):
 
 
 class TokenManagerConfig(BaseModel):
-    max_context_tokens: int = Field(
-        default=200000,
+    max_context_tokens: int | None = Field(
+        default=None,
         ge=1024,
-        description="Maximum number of tokens allowed in the context window for optimal performance",
+        description=(
+            "Prompt-side context budget in tokens. Leave null (recommended) to "
+            "derive it from the answer model's own context window minus its "
+            "output reservation — a hardcoded value silently overflows a smaller "
+            "model's window and wastes a larger one. An explicit value is "
+            "honoured but clamped to what the model can actually accept."
+        ),
+    )
+    context_window_headroom_ratio: float = Field(
+        default=0.1,
+        gt=0.0,
+        lt=1.0,
+        description=(
+            "Fraction of the answer model's context window held back when "
+            "deriving max_context_tokens, covering the system prompt, the "
+            "question, conversation history, and tokenizer estimation error."
+        ),
     )
     token_count_cache_size: int = Field(
         default=1024,
@@ -1592,19 +1631,19 @@ class SearchConfig(BaseModel):
         description="Language model identifier used for translating queries into the target language",
     )
     entity_extraction_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model identifier used for extracting named entities from user queries",
     )
     strategy_selection_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model identifier used for automatically selecting the optimal search strategy",
     )
     context_building_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model identifier used for building and structuring contextual information",
     )
     answer_generation_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model identifier used for generating final answers from retrieved context",
     )
     hybrid: HybridConfig = Field(
@@ -1835,7 +1874,7 @@ class EvaluationConfig(BaseModel):
         description="Embedding model identifier for evaluation",
     )
     evaluation_model_id: LanguageModelId = Field(
-        default=LanguageModelId.CLAUDE_V4_5_SONNET,
+        default=LanguageModelId.CLAUDE_V5_SONNET,
         description="Language model identifier used for evaluation",
     )
     enabled_evaluators: list[EvaluatorType] = Field(


### PR DESCRIPTION
## Summary

Adds **Claude Sonnet 5** and **Opus 5**, making Sonnet 5 the default for reasoning-heavy stages (Haiku 4.5 stays on light ones). Along the way this fixes two latent bugs found while verifying the migration against real Bedrock.

Two commits, reviewable independently:

| Commit | Change |
|---|---|
| `15bfe73` | `fix(bedrock)`: CountTokens request/response shape |
| `d2543d5` | `feat(bedrock)`: Claude 5 models + derived context budget |

## 1. CountTokens has never worked

Every `count_tokens` call has been failing since it was written: the request passed `converse=` at the top level (the API nests it under `input`), and the response key is `inputTokens`, not `totalTokens`. Both were invisible — `count_tokens()` catches `Exception` and degrades to the script-aware estimate, logging at debug level only. **The test fake mirrored the same wrong shape**, so the suite passed while no real call ever succeeded.

Measured in `ap-northeast-2`, the estimate diverges in both directions (~2.4× under on short strings, ~1.4× over on realistic retrieval context), so context budgeting was working from wrong numbers.

## 2. Adding Claude 5 needs more than enum entries

Three request-shape changes return 400 on these models, all verified live:

- **Sampling parameters dropped** — Claude 4.7+ removed `temperature`/`top_p`/`top_k`; the documented migration is to omit them.
- **Adaptive thinking + `effort`** — the old `budget_tokens` shape is rejected, and `effort` nested inside `thinking` is a `ValidationException`, so it goes in a sibling `output_config`. Sonnet 5 cannot disable thinking, so the adaptive block (which carries `effort`) is always sent — `--enable-thinking` is a no-op there.
- **`context-1m-2025-08-07` suppressed** — 1M is the default window on Claude 5.

Claude 5 is also **INFERENCE_PROFILE-only**, and `ap-northeast-2` publishes only `global.` profiles for it — no `apac.`. Resolution used to fall back to the bare id, which is not invocable, surfacing later as an opaque Bedrock error. It now fails fast with the remedy.

**Fable 5 is deliberately not offered**: it requires the account's data-retention mode set to `provider_data_share` (Data Retention API only, no console UI), so it would fail on most accounts, and its pricing exceeds the Opus tier.

## 3. Context budget was disconnected from the model

`max_context_tokens` was a hardcoded `200000` that no model informed, while `context_window_size` was declared and never read. A window must hold the prompt *and* the answer, so `200000` + a 200K model's 64K output reservation **overflowed the window by 64K** on Sonnet 4.5 and Haiku 4.5.

It now defaults to `null` and derives from the answer model's window minus its output reservation and a configurable headroom; an explicit value is honoured but clamped, with a warning.

| Answer model | Derived | Previously |
|---|---|---|
| Sonnet 5 (1M / 128K) | 784,800 | 200,000 (20% of window used) |
| Sonnet 4.5 (200K / 64K) | 122,400 | 200,000 (**overflow**) |
| Haiku 4.5 (200K / 64K) | 122,400 | 200,000 (**overflow**) |

This also revives `supports_1m_context_window`, which was **dead** — no caller ever passed the kwarg it was gated on, so the beta header could never be sent. It is now driven by `aws.bedrock.enable_1m_context`, off by default because those models bill long context at a premium.

## Testing

- **1825 passed**, coverage 81.32% (gate: 78%); ruff/isort/black/mypy clean via pre-commit.
- **Real Bedrock in `ap-northeast-2`**: graph + claim extraction with XML parsing, keyword extraction, description summarization, community reports, embeddings, and budget derivation. All five effort levels accepted on both models.
- **Not run**: full-pipeline E2E — Neptune and OpenSearch are not currently deployed.

## Reviewer notes

- `context_window_headroom_ratio` defaults to `0.1`. It is a conservative estimate, not a measured value — it covers the system prompt, question, history, and tokenizer error. Claude 5 does **not** support CountTokens on `bedrock-runtime`, so those models still use the estimate.
- Sonnet 5 always thinks, so output tokens rise ~33% vs Sonnet 4.5 at the default `effort: high`. `medium` lands near the old token volume; the default follows AWS's recommendation.