### PR TITLE
fix(deps): raise aws-cdk-lib floor and add Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependabot version updates. Security *alerts* are already enabled on the
+# repository and have been driving the fix(deps) history, but alerts only fire
+# for dependencies whose version is pinned: everything in uv.lock is, while
+# iac/requirements.txt declares ranges only, so its packages reach the
+# dependency graph with no version and are never matched against an advisory.
+# Scheduled version updates cover that gap and keep the SHA-pinned workflow
+# actions moving, which no other path can do.
+version: 2
+
+updates:
+  # Application runtime + dev dependencies (pyproject.toml, uv.lock).
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # One PR per weekly batch of non-breaking bumps keeps main's history
+      # readable; majors stay separate so they get their own review.
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # CDK app. Kept out of the root lock on purpose: it is deployment tooling that
+  # ships nothing and shares no runtime with the package, so keeping it separate
+  # avoids coupling the app's resolution to the CDK dependency tree (notably
+  # aws-cdk.aws-neptune-alpha's exact `typeguard` pin). The cost of that
+  # separation is that these ranges are unpinned and therefore invisible to
+  # security alerts; `increase-if-necessary` lets Dependabot raise a floor when
+  # -- and only when -- the existing range cannot admit the fixed version.
+  - package-ecosystem: "pip"
+    directory: "/iac"
+    versioning-strategy: "increase-if-necessary"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "fix(deps)"
+    groups:
+      aws-cdk:
+        # aws-cdk-lib and aws-cdk.aws-neptune-alpha are released in lockstep and
+        # the alpha module pins an exact aws-cdk-lib version, so bumping one
+        # without the other cannot resolve.
+        patterns: ["aws-cdk*", "constructs"]
+
+  # Workflow actions are pinned to commit SHAs (see .github/workflows/*.yml), so
+  # they are invisible to every other update path.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/iac/requirements.txt
+++ b/iac/requirements.txt
@@ -1,4 +1,9 @@
-aws-cdk-lib>=2.214.0,<3.0.0
-aws-cdk.aws-neptune-alpha>=2.214.0a0
-constructs>=10.0.0,<11.0.0
+# aws-cdk-lib floor is 2.253.0, the release that fixed the inverted CodeBuild
+# S3LoggingOptions.encrypted flag (GHSA-464c-974j-9xm6). This stack defines no
+# CodeBuild project, so it was never exposed, and a resolve today lands well
+# past the fix anyway — the floor is here so the constraint states the security
+# requirement outright and cannot resolve backwards into the affected range.
+aws-cdk-lib>=2.253.0,<3.0.0
+aws-cdk.aws-neptune-alpha>=2.253.0a0
+constructs>=10.5.0,<11.0.0
 cdk-nag>=2.27.0,<3.0.0


### PR DESCRIPTION
## Summary

Two related dependency-hygiene changes, one commit each.

**`fix(deps)`** — raise the `aws-cdk-lib` floor to 2.253.0 for GHSA-464c-974j-9xm6. Releases before 2.253.0 pass CodeBuild's `S3LoggingOptions.encrypted` straight through to the CloudFormation `EncryptionDisabled` field without negating it, so an explicit value takes effect inverted. The `constructs` floor moves to 10.5.0, which `aws-cdk.aws-neptune-alpha` requires from 2.253.0a0 onward.

**`ci`** — add `.github/dependabot.yml` covering the root `uv` project, `iac/`, and the workflow actions.

## Exposure

None. The CDK app defines no CodeBuild project, so `S3LoggingOptions` is never constructed — the only S3 logging configuration in `iac/` is the OpenSearch `LoggingOptions` in `stacks/storage_stack.py`, a different module. A resolve against the previous constraint also already landed on 2.262.1, well past the fix. The floor is here so the constraint states the requirement rather than admitting the affected range.

## Why Dependabot config, given alerts are already on

Security alerts are enabled and have been driving the `fix(deps)` history, but they only match dependencies whose version is resolved. `iac/requirements.txt` declares ranges only, so its packages reach the dependency graph with no version attached and are never compared against an advisory — this advisory included, which is why it surfaced through an external SBoM scan instead. Workflow actions are pinned to commit SHAs and no other path moves them. Scheduled version updates cover both.

`versioning-strategy: increase-if-necessary` on the `iac/` entry keeps Dependabot from rewriting floors that already admit the fixed version.

## Follow-up, not in this PR

`iac/` stays unpinned, so security alerts still cannot see it; version updates narrow the gap but are not as immediate. Pinning it (`requirements.in` compiled to a pinned `requirements.txt`) would close it properly and needs a CI change, so it is left as separate work.

## Verification

- `uv pip compile` on both the old and new constraints — resolves to `aws-cdk-lib==2.262.1`, unchanged
- `uv pip install --dry-run -r iac/requirements.txt` — no changes against the existing environment
- pre-commit (`check-yaml`, whitespace, merge-conflict) passes
- `dependabot.yml` parses; three update configs