### PR TITLE
chore(ci): stop Dependabot proposing two known-breaking bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
       # loaders move off langchain-community (it is in sunset as of 0.4).
       - dependency-name: "langchain-community"
         versions: [">=0.4.0"]
+      # Repeated from the /iac entry on purpose: this ecosystem also picks up
+      # iac/requirements.txt (it proposed the cdk-nag 3.0 and constructs bumps
+      # against that file), so an ignore only on /iac would not stop it.
+      - dependency-name: "cdk-nag"
+        versions: [">=3.0.0"]
 
   # CDK app. Kept out of the root lock on purpose: it is deployment tooling that
   # ships nothing and shares no runtime with the package, so keeping it separate

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,14 @@ updates:
       minor-and-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # Held below 0.4 deliberately: ragas imports a langchain-community module
+      # that 0.4 removed, so raising this breaks the evaluator at import time.
+      # Dependabot proposed exactly that bump and CI caught it; the constraint
+      # carries the reason in pyproject.toml. Revisit when the parser's document
+      # loaders move off langchain-community (it is in sunset as of 0.4).
+      - dependency-name: "langchain-community"
+        versions: [">=0.4.0"]
 
   # CDK app. Kept out of the root lock on purpose: it is deployment tooling that
   # ships nothing and shares no runtime with the package, so keeping it separate
@@ -47,6 +55,13 @@ updates:
         # the alpha module pins an exact aws-cdk-lib version, so bumping one
         # without the other cannot resolve.
         patterns: ["aws-cdk*", "constructs"]
+    ignore:
+      # cdk-nag 3.0 no longer exports NagSuppressions, which nag_suppressions.py
+      # imports, so `cdk synth` fails at import time. Porting to the 3.x API is
+      # its own change; until then a bump here only produces a red PR. Drop this
+      # entry as part of that migration.
+      - dependency-name: "cdk-nag"
+        versions: [">=3.0.0"]
 
   # Workflow actions are pinned to commit SHAs (see .github/workflows/*.yml), so
   # they are invisible to every other update path.


### PR DESCRIPTION
## Summary

Dependabot's first batch included two bumps that cannot succeed. Both failed CI; this records why so they stop coming back.

**`langchain-community >= 0.4.0`** (proposed in #22) — ragas imports `langchain_community.chat_models.vertexai` unconditionally, and 0.4 removed that module. It is still removed in ragas 0.4.3, the latest release, which is why the constraint is held at `<0.4.0` with the reason in `pyproject.toml`. #22 raised it to `>=0.4.2` and `quality`/`markers` failed.

**`cdk-nag >= 3.0.0`** (proposed in #20 and #15) — 3.0 no longer exports `NagSuppressions`, which `iac/nag_suppressions.py` imports, so the `iac` job fails before synth begins:

```
ImportError: cannot import name 'NagSuppressions' from 'cdk_nag'
```

## Not permanent

Each entry names the migration that retires it — moving the parser's document loaders off langchain-community (in sunset as of 0.4), and porting the suppressions module to the cdk-nag 3.x API. Both are tracked separately; neither belongs in a dependency bump.

## Note on the duplicate

#20 and #15 both target `cdk-nag` from the same starting constraint with different results (`>=3.0.1,<4.0.0` vs `>=2.27.0,<4.0.0`) — the `/iac` entry sets `versioning-strategy: increase-if-necessary` and the root does not, so the same package was evaluated twice under different strategies. The ignore entry on `/iac` stops the one that breaks synth; the root ecosystem does not track `iac/requirements.txt`, so no second entry is needed.