### PR TITLE
fix(lightrag): hybrid needs the KG-linked chunk stream and the per-type quota

### DIFF
--- a/tests/unit/test_lightrag_search.py
+++ b/tests/unit/test_lightrag_search.py
@@ -487,9 +487,13 @@ class TestUpstreamTwoRetrievalWidths:
         assert widths[os_config.relationships_index_prefix] == 25
         assert widths[os_config.text_units_index_prefix] == 12
 
-    async def test_non_mix_modes_keep_a_flat_width(self, config: Config) -> None:
-        # HYBRID has no chunk blend and no quota; only mix is realigned here, so the
-        # other modes must be untouched by this fix.
+    async def test_hybrid_gets_the_same_quota_as_mix(self, config: Config) -> None:
+        # HYBRID runs the same three streams as mix (ll->entities, hl->relationships,
+        # KG-linked chunks); mix only adds the naive VECTOR chunk blend on top. Gating
+        # the quota on mix alone left hybrid taking a flat top_k cut — 10 contexts
+        # against upstream hybrid's 188 — and abstaining on 55/100 MuSiQue queries for
+        # lack of evidence (F1 .236 vs upstream .567). The previous version of this test
+        # asserted that no-quota behaviour as intended, which encoded the defect.
         strategy, _, _ = _make_strategy(config)
         captured: dict = {}
 
@@ -503,7 +507,28 @@ class TestUpstreamTwoRetrievalWidths:
                 SearchStrategy.HYBRID, ll_keywords=["a"], hl_keywords=["b"], top_k=10
             )
         )
+        quota = captured.get("per_type_quota")
+        assert quota is not None
+        assert quota["text"] == config.search.lightrag_search.chunk_stream_top_k
+        assert quota["entity"] >= config.search.lightrag_search.kg_stream_top_k
+        assert quota["relationship"] >= config.search.lightrag_search.kg_stream_top_k
+        # And the rerank stays scoped to chunks, as for mix.
+        assert captured.get("rerank_only_types") == {"text"}
+
+    async def test_naive_keeps_a_flat_width(self, config: Config) -> None:
+        # naive retrieves ONE stream (vector chunks), so there is nothing to reserve
+        # slots against and a flat top_k is correct.
+        strategy, _, _ = _make_strategy(config)
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, retrieval_multiplier=1, query=None, **kw):
+            captured.update(kw)
+            return [r for results in results_dict.values() for r in results]
+
+        strategy.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        await strategy.asearch(_query(SearchStrategy.NAIVE, top_k=10))
         assert captured.get("per_type_quota") is None
+        assert captured.get("rerank_only_types") is None
 
     def test_linked_chunk_pool_is_bounded_by_the_chunk_width(self) -> None:
         # The lineage pool is a CHUNK stream, so it follows chunk_top_k (20), not the
@@ -1095,3 +1120,62 @@ class TestEndpointSeedingIsPreserved:
         assert set(neptune_r.calls[0].filters["id"]) == {"e1", "e2"}
         # ...and also emitted as their own entity candidates.
         assert captured["sources"]["lightrag_endpoint_entities"]
+
+
+class TestHybridHasAChunkStream:
+    """Upstream `hybrid` builds context from entities + relations + THEIR chunks.
+
+    `_find_related_text_unit_from_entities` / `_from_relations` run for hybrid too —
+    upstream hybrid's context measured ~190 text items. What `mix` adds is the
+    separate naive VECTOR chunk query. Gating the lineage chunks on mix left hybrid
+    with no chunk stream at all, and it abstained on 55/100 MuSiQue queries.
+    """
+
+    @staticmethod
+    def _lineage_strategy(config: Config, strategy: SearchStrategy):
+        spec = get_strategy_spec(strategy)
+        st = spec.strategy_class(
+            config=config,
+            retrievers={
+                RetrieverRole.DOCUMENT.value: LineageRetriever(),
+                RetrieverRole.GRAPH.value: FakeRetriever("graph"),
+            },
+        )
+        captured: dict = {}
+
+        def _fake_fuse(results_dict, top_k, retrieval_multiplier=1, query=None, **kw):
+            captured["sources"] = results_dict
+            captured.update(kw)
+            return [r for results in results_dict.values() for r in results]
+
+        st.hybrid_scorer.fuse_and_rerank_results = _fake_fuse  # type: ignore[method-assign]
+        return st, captured
+
+    async def test_hybrid_retrieves_kg_linked_chunks(self, config: Config) -> None:
+        st, captured = self._lineage_strategy(config, SearchStrategy.HYBRID)
+        await st.asearch(
+            _query(SearchStrategy.HYBRID, ll_keywords=["a"], hl_keywords=["b"])
+        )
+        sources = captured["sources"]
+        assert any(
+            "linked" in key for key in sources
+        ), f"hybrid produced no KG-linked chunk stream: {sorted(sources)}"
+
+    async def test_hybrid_does_not_run_the_naive_vector_blend(
+        self, config: Config
+    ) -> None:
+        # That blend is what distinguishes mix from hybrid upstream.
+        st, captured = self._lineage_strategy(config, SearchStrategy.HYBRID)
+        await st.asearch(
+            _query(SearchStrategy.HYBRID, ll_keywords=["a"], hl_keywords=["b"])
+        )
+        assert "lightrag_chunks" not in captured["sources"]
+
+    async def test_mix_still_runs_both_chunk_streams(self, config: Config) -> None:
+        st, captured = self._lineage_strategy(config, SearchStrategy.MIX)
+        await st.asearch(
+            _query(SearchStrategy.MIX, ll_keywords=["a"], hl_keywords=["b"])
+        )
+        sources = captured["sources"]
+        assert "lightrag_chunks" in sources
+        assert any("linked" in key for key in sources)

--- a/unified_kg_rag/adapters/search_strategies/lightrag_search.py
+++ b/unified_kg_rag/adapters/search_strategies/lightrag_search.py
@@ -279,18 +279,23 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
                 if endpoints:
                     results_by_source.update(endpoints)
 
+            # KG-grounded chunks: follow text_unit_ids lineage from the matched
+            # entities/relationships to their source chunks. BOTH KG modes do this —
+            # upstream `hybrid` builds its context from entities + relations + the
+            # chunks those reference (`_find_related_text_unit_from_entities` /
+            # `_from_relations`), which is why upstream hybrid's context is ~190 text
+            # items. Gating this on mix left hybrid with NO chunk stream at all, so it
+            # abstained on 55/100 MuSiQue queries. What `mix` adds on top is the
+            # separate naive VECTOR chunk query, not the lineage chunks.
+            #
+            # For mix the naive vector chunks are fetched FIRST and passed to the
+            # lineage selection as `exclude`, because upstream merges the three chunk
+            # streams round-robin under one `seen_chunk_ids` set with the vector stream
+            # taking precedence (operate.py `_merge_chunks`). Selecting the lineage
+            # chunks blind to that set spent 37% of the KG chunk budget re-fetching
+            # chunks the vector query had already delivered.
+            vector_chunk_ids: set[str] = set()
             if mode == SearchStrategy.MIX.value:
-                # KG-grounded chunks: follow text_unit_ids lineage from the
-                # matched entities/relationships to their source chunks, then
-                # blend a naive vector chunk query.
-                #
-                # The naive vector chunks are fetched
-                # FIRST and passed to the lineage selection as `exclude`, because
-                # upstream merges the three chunk streams round-robin under one
-                # `seen_chunk_ids` set with the vector stream taking precedence
-                # (operate.py `_merge_chunks`). Selecting the lineage chunks
-                # blind to that set spent 37% of the KG chunk budget re-fetching
-                # chunks the vector query had already delivered.
                 results_by_source.update(await self._retrieve_chunks(query))
                 vector_chunk_ids = {
                     cid
@@ -299,14 +304,14 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
                     )
                     if cid
                 }
-                linked = await self._retrieve_linked_chunks(
-                    query,
-                    results_by_source.get("lightrag_entities", []),
-                    results_by_source.get("lightrag_relationships", []),
-                    exclude=vector_chunk_ids,
-                )
-                if linked:
-                    results_by_source.update(linked)
+            linked = await self._retrieve_linked_chunks(
+                query,
+                results_by_source.get("lightrag_entities", []),
+                results_by_source.get("lightrag_relationships", []),
+                exclude=vector_chunk_ids,
+            )
+            if linked:
+                results_by_source.update(linked)
 
         # Keep entities/relationships/chunks as separate streams
         # with reserved slots (LightRAG uses ~40 entities / 20 chunks), instead of
@@ -315,7 +320,7 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
         # answer lives in them; entities/relationships get the rest. Non-mix modes and
         # the no-quota path are unchanged.
         per_type_quota = None
-        if mode == SearchStrategy.MIX.value:
+        if mode in (SearchStrategy.MIX.value, SearchStrategy.HYBRID.value):
             k = query.top_k
             # The quota has to match upstream's TWO widths (see the module comment on
             # kg_stream_top_k / chunk_stream_top_k), otherwise widening the vector
@@ -356,7 +361,9 @@ class LightRAGSearchStrategy(BaseSearchStrategy):
         # multi-hop bridge entities/relations whose description lacks the question's
         # surface terms (LightRAG reranks chunks only).
         rerank_only_types = (
-            {SectionType.TEXT.value} if mode == SearchStrategy.MIX.value else None
+            {SectionType.TEXT.value}
+            if mode in (SearchStrategy.MIX.value, SearchStrategy.HYBRID.value)
+            else None
         )
         final_results = self.hybrid_scorer.fuse_and_rerank_results(
             results_by_source,


### PR DESCRIPTION
## Summary

Two gates in `LightRAGSearchStrategy.asearch` were keyed on `mode == MIX` when they should cover both KG modes. As a result `hybrid` ran with no chunk stream at all and a flat `top_k` cut, and answered `unknown` on over half the queries in a multi-hop benchmark for lack of evidence.

## Measured impact

Against upstream LightRAG (`lightrag` package, same corpus, same graph, same short-answer prompt), n=100 per dataset:

| dataset | mode | before | after | upstream | McNemar p (after) |
|---|---|---|---|---|---|
| MuSiQue | **hybrid** | **.236** | **.648** | .567 | .5034 |
| 2Wiki | **hybrid** | — | **.644** | .629 | 1.0000 |
| MuSiQue | mix | .631 | .626 | .591 | .4545 |
| 2Wiki | mix | .653 | .665 | .629 | .8145 |

`hybrid` gains **+.41 token-F1** on MuSiQue and lands above upstream on both datasets. `mix` does not regress (−.005 / +.012, both inside the measured run-to-run noise band). The two datasets agree, so this is not an artifact of the one the defect was found on.

Before the fix, `hybrid` retrieved a median of **10** contexts against upstream's **188**, and abstained (`unknown`) on **55 of 100** MuSiQue queries.

## What changed

**1. The KG-linked chunk stream now runs for `hybrid` too.**

Upstream `hybrid` builds its context from entities + relations + *the chunks those reference* (`_find_related_text_unit_from_entities` / `_from_relations`), which is why its context measures ~190 text items. Gating the lineage-chunk retrieval on `mix` left `hybrid` with no chunk stream whatsoever. What `mix` adds on top is the separate **naive vector chunk query** — not the lineage chunks.

**2. `hybrid` gets the same per-type quota (and chunks-only rerank scoping) as `mix`.**

Both modes run the same three streams, so without the quota `hybrid` fell through to `combined_results[:top_k]`, truncating even the streams it did retrieve to 10 items.

`naive` deliberately stays on the flat path: it retrieves one stream, so there are no competing types to reserve slots against.

## Tests

`test_non_mix_modes_keep_a_flat_width` asserted the no-quota behaviour as intended (*"HYBRID has no chunk blend and no quota; only mix is realigned here"*) — that assertion encoded the defect. It is replaced by:

- `test_hybrid_gets_the_same_quota_as_mix` — hybrid receives the two-width quota and the chunks-only rerank scoping
- `test_naive_keeps_a_flat_width` — naive still passes no quota (the narrow claim the old test should have made)
- `TestHybridHasAChunkStream` — hybrid gets the lineage chunks; hybrid does **not** get the naive vector blend (that is what distinguishes it from mix); mix still runs both

Suite: 1829 passed, coverage 80.96% (gate 78%). `ruff`, `black`, `isort`, `mypy` clean.