### PR TITLE
fix: honour the declared Python 3.10 floor

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -59,6 +59,28 @@ jobs:
             report.xml
           if-no-files-found: ignore
 
+  oldest-python:
+    # The quality job runs one interpreter, so nothing checked the LOWER bound of
+    # requires-python. It was broken: html_exporter imported `datetime.UTC`, which
+    # is 3.11+, so every install on the declared minimum failed at import. Run the
+    # suite on the floor to keep that bound honest.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Sync dependencies
+        # --frozen: resolve nothing, install exactly what the committed lock
+        # pins, so this also proves the lock itself is installable on the floor.
+        run: uv sync --python 3.10 --frozen --extra dev
+
+      - name: pytest
+        run: uv run --python 3.10 --frozen pytest -m "not aws" -q
+
   markers:
     # Verify the property and integration suites pass in isolation, so a suite
     # that is accidentally excluded from the default selection can't rot unseen.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,10 @@ only-include = ["unified_kg_rag", "README.md", "LICENSE", "pyproject.toml"]
 
 [tool.black]
 line-length = 88
-target-version = ['py311', 'py312']
+# Match requires-python's floor. These were py311, which let ruff's pyupgrade
+# rewrite `timezone.utc` to the 3.11-only `datetime.UTC` and broke every install
+# on the declared minimum.
+target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -160,7 +163,10 @@ skip_gitignore = true
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+# Must track requires-python's floor: pyupgrade (UP) rewrites code to the target
+# version's idioms, so py311 here actively introduced 3.11-only syntax into a
+# package that claims 3.10 support.
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [
@@ -190,7 +196,9 @@ ignore = [
 "tests/**/*.py" = ["B018"]
 
 [tool.mypy]
-python_version = "3.11"
+# Type-check against the oldest supported interpreter, so stdlib symbols added
+# after it are reported here rather than at a user's import time.
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/unified_kg_rag/visualization/exporters/html_exporter.py
+++ b/unified_kg_rag/visualization/exporters/html_exporter.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from html import escape as _html_escape
 from pathlib import Path
 from typing import Any
@@ -98,7 +98,9 @@ class HTMLExporter:
         centrality_html, centrality_js = self._render_centrality(
             data.get("centrality_data") or {}
         )
-        report_date = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+        # `datetime.UTC` is 3.11+; this package supports 3.10 (see
+        # requires-python), where only `timezone.utc` exists.
+        report_date = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
         return f"""
         <body>


### PR DESCRIPTION
## Summary

`requires-python = ">=3.10"`, but importing the visualization package on 3.10 raised:

```
unified_kg_rag/visualization/exporters/html_exporter.py:3
  ImportError: cannot import name 'UTC' from 'datetime'
```

`datetime.UTC` is 3.11+. Every install on the declared minimum was broken.

## The cause is tooling config, not the line of code

Fixing the import by hand does not hold — ruff rewrites it straight back. All three tools were configured a version above the package's own floor:

| Tool | Was | Now |
|---|---|---|
| black `target-version` | `['py311', 'py312']` | `['py310', 'py311', 'py312']` |
| ruff `target-version` | `"py311"` | `"py310"` |
| mypy `python_version` | `"3.11"` | `"3.10"` |

ruff's pyupgrade (`UP`) rules rewrite code to the configured target, so `py311` was **actively introducing** 3.11-only syntax into a package claiming 3.10 support. `datetime.UTC` is the symptom; the mismatch is the defect.

With the targets aligned, `timezone.utc` is the only source change needed — mypy against 3.10 reports no further post-3.10 stdlib use across 125 files.

## Why CI missed it

Every job pinned 3.12, so nothing exercised the lower bound. Added an `oldest-python` job that installs the committed lock with `--frozen` on 3.10 and runs the suite, which also proves the lock resolves on the floor rather than only on 3.12.

## Verification

- Python 3.10: 1829 passed (the failure reproduced first, then cleared)
- Python 3.12: 1829 passed, coverage 81.32% (gate 78%) — no regression
- ruff, black, mypy clean under the new targets
- `cdk synth` exits 0

## Note

This predates the recent dependency work — it is present in the initial public commit. It surfaced while adversarially reviewing that work, where verifying the interpreter floor after a large dependency bump should have happened earlier.