### PR TITLE
fix(deps): pin gremlinpython below 3.8 for Neptune compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,13 @@ updates:
       # loaders move off langchain-community (it is in sunset as of 0.4).
       - dependency-name: "langchain-community"
         versions: [">=0.4.0"]
+      # 3.8 added the `discard()` step and sends `Cardinality.single` writes
+      # through it; Neptune rejects the step, so every graph write fails and an
+      # ingest indexes 0 entities. This bump WAS merged and only a real-AWS run
+      # caught it — the fake Neptune client in the unit suite cannot. Raise when
+      # Neptune's engine supports TinkerPop 3.8.
+      - dependency-name: "gremlinpython"
+        versions: [">=3.8.0"]
       # Repeated from the /iac entry on purpose: this ecosystem also picks up
       # iac/requirements.txt (it proposed the cdk-nag 3.0 and constructs bumps
       # against that file), so an ignore only on /iac would not stop it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,14 @@ dependencies = [
     "datasets>=4.0.0",
     "datasketch>=2.0.0",
     "graspologic>=3.4.1",
-    "gremlinpython>=3.8.1,<3.9.0",
+    # Pinned below 3.8: that release added the `discard()` step and routes
+    # `Cardinality.single` property writes through it, which Neptune (engine
+    # 1.4.7.0, TinkerPop 3.6/3.7) rejects with
+    # `InternalFailureException: Could not locate method:
+    # NeptuneGraphTraversal.discard()`. Every vertex and edge write fails, so a
+    # real ingest indexes 0 entities. Unit tests use a fake Neptune client and
+    # cannot see this. Raise only once Neptune's engine reports TinkerPop 3.8.
+    "gremlinpython>=3.6.3,<3.8.0",
     # LangChain 1.x. The floors are the releases that carry the fixes for
     # GHSA-qh6h-p6c9-ff54 (langchain-core path traversal), GHSA-gr75-jv2w-4656
     # (langchain loader path traversal), GHSA-fv5p-p927-qmxr (splitter SSRF) and

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "gremlinpython"
-version = "3.8.1"
+version = "3.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -1295,9 +1295,9 @@ dependencies = [
     { name = "isodate" },
     { name = "nest-asyncio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/56/8867126fc3383ba2aea606e54079353d15568508cf7c60255f727780be8c/gremlinpython-3.8.1.tar.gz", hash = "sha256:23ad0ed694d63ef57611a04d3c648cc6bf05e86678959b6b6d921e83c48fd1f8", size = 53968, upload-time = "2026-04-07T00:22:20.144Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/67/a9f9b8380d9db4667f04a5e38c1725a337baf6d114a4b608b5faad45c632/gremlinpython-3.7.6.tar.gz", hash = "sha256:a13df1a47c493b8c4d5c9b79b6db5295080ee51b4ebf4987232a120b1b749b3c", size = 52704, upload-time = "2026-04-06T23:12:05.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/55/f6adf83dd74563aca7721d456b1d33d7656448e29cc79a6aede3bb6ffa5b/gremlinpython-3.8.1-py3-none-any.whl", hash = "sha256:2e8136f9ea8cd771f9cc6f86f4ce73130595aed414a363534e1a4e18bfa81427", size = 75457, upload-time = "2026-04-07T00:22:18.776Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5d/a2a3016f7c902ab361a01df58949350a94622cb4985ca8304724866948f6/gremlinpython-3.7.6-py3-none-any.whl", hash = "sha256:14fdf6003ebed1b6463c321df67b1e9f4a4893b4e38c9d181cf26ded49a389d7", size = 73962, upload-time = "2026-04-06T23:12:03.803Z" },
 ]
 
 [[package]]
@@ -4904,7 +4904,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "datasketch", specifier = ">=2.0.0" },
     { name = "graspologic", specifier = ">=3.4.1" },
-    { name = "gremlinpython", specifier = ">=3.8.1,<3.9.0" },
+    { name = "gremlinpython", specifier = ">=3.6.3,<3.8.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.163.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "langchain", specifier = ">=1.3.9,<2.0.0" },


### PR DESCRIPTION
## Summary

gremlinpython 3.8 added the `discard()` step and routes `Cardinality.single` property writes through it. Neptune rejects the step outright:

```
InternalFailureException: Could not locate method: NeptuneGraphTraversal.discard()
```

Every vertex and edge write fails. Against a live cluster (engine 1.4.7.0), ingestion completed 9 stages and then indexed **0 of 32 entities and 0 of 9 communities** — the graph came out empty while the pipeline reported per-item failures.

The regression arrived in the grouped dependency bump that raised `gremlinpython` from `>=3.6.3,<3.7.0` to `>=3.8.1,<3.9.0`. Reverting to `<3.8.0` resolves to 3.7.6, which has no `discard` (`hasattr(GraphTraversal, "discard")` is `False`).

## Why CI passed

The unit suite drives a fake Neptune client, so no test exercises the wire protocol. `cdk synth` and the AWS-free suite cannot observe a step the server refuses. This is only visible against a real cluster, which is how it was found.

A Dependabot `ignore` entry is added so the bump does not return weekly; it records the condition for lifting it (Neptune's engine reporting TinkerPop 3.8).

## Verification

Re-ran the full pipeline on the corrected image against live Neptune + OpenSearch + Bedrock:

```
GRAPH EXTRACTION  - COMPLETED (19 entities, 33 relationships)
GLEANING          - COMPLETED (19 -> 33 entities, 33 -> 70 relationships)
GRAPH RESOLUTION  - COMPLETED (33 -> 33, 70 -> 70)
CLAIM EXTRACTION  - COMPLETED (30 claims)
GRAPH ANALYSIS    - COMPLETED (63 nodes, 121 edges)
COMMUNITY DETECT  - COMPLETED (5 communities, 5 reports)
INDEXING          - COMPLETED (248 items indexed, 0 failed)
Pipeline: 12 stages completed, 0 failed
```

Retrieval then verified across four strategies (`hybrid`, `mix`, `local`, `global`) — all exit 0, with Neptune and OpenSearch both queried and fusion running. The generated answer correctly joined facts across two source documents.

Local: 1829 tests pass, coverage 81.32%, pre-commit clean.

## Note

This also gave the first real-AWS confirmation of #29: LightRAG `hybrid` retrieved **138 results**, matching `mix`, rather than being truncated to a flat `top_k`.