### PR TITLE
docs: fix Korean emphasis rendering and align translation parity

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,5 +1,8 @@
 # Unified Knowledge Graph RAG on AWS
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
+[![Python](https://img.shields.io/badge/python-3.10--3.12-blue.svg)](https://www.python.org/downloads/)
+
 🇬🇧 **[English README](./README.md)** · 🤝 **[기여 가이드](./CONTRIBUTING.md)**
 
 <p align="center">
@@ -9,6 +12,25 @@
 대규모 다국어 문서 코퍼스를 지식 그래프로 변환하고, 멀티홉 그래프 순회로 질의에 답하는 **AWS 네이티브 Knowledge Graph RAG 프레임워크**입니다.
 
 두 검색 방법론 — Microsoft GraphRAG(*"From Local to Global: A Graph RAG Approach to Query-Focused Summarization"*)와 LightRAG(*"Simple and Fast Retrieval-Augmented Generation"*) — 를 단일 AWS 네이티브 스택(Bedrock, Neptune, OpenSearch, S3, DynamoDB) 위에 재구현했습니다. 두 방법론은 질의마다 선택 가능하며 동일한 인제스천·인덱싱·캐싱·다국어·하이브리드 검색 인프라를 공유합니다.
+
+> **핵심 요약**
+> - **두 방법론, 하나의 스택.** GraphRAG 커뮤니티 요약(`auto`/`drift`/`global`/`local`/`simple`)과 LightRAG 이중 레벨 키워드(`mix`/`hybrid`/`naive`)를 `search_strategy`로 질의마다 선택합니다.
+> - **증분 인덱싱.** DynamoDB 문서-상태 레지스트리(`aws.dynamodb`)가 콘텐츠 해시로 코퍼스를 비교해 신규/변경 문서만 재인덱싱하고 라이브 그래프에 병합합니다(멱등 upsert; 삭제 시 해당 문서 독점 아티팩트만 제거).
+> - **프롬프트 튜닝.** `run-prompt-tuning`이 코퍼스를 프로파일링(도메인/언어/페르소나/엔티티 타입)해 도메인 적응 `custom_prompts`를 생성합니다.
+> - **독립 시각화 & 그래프 인식 평가.** `run-visualization`은 재인제스천 없이 렌더하고, `graph_aware` 평가자는 엔티티/관계 커버리지를 채점합니다.
+> - **헥사고날 아키텍처.** 포트 & 어댑터 + 레지스트리로 스토리지 백엔드·검색 전략·평가자·렌더러를 교체 가능하게 만듭니다. [`docs/design.ko.md`](./docs/design.ko.md) 참고.
+
+## 📋 목차
+
+- [✨ 핵심 특징](#-핵심-특징)
+- [🏛️ 아키텍처 개요](#-아키텍처-개요)
+- [🚀 설치](#-설치)
+- [📖 사용법](#-사용법)
+- [🧪 테스트 & 품질](#-테스트--품질)
+- [🔒 보안 & 면책](#-보안--면책)
+- [🤝 기여](#-기여)
+- [📄 라이선스](#-라이선스)
+- [📚 참고문헌](#-참고문헌)
 
 ---
 
@@ -70,6 +92,8 @@
 
 ### 인제스천 파이프라인 (12단계)
 
+![인제스천 파이프라인](./assets/ingestion_pipeline.png)
+
 문서 파싱 → 로딩 → 청킹 → (번역) → 그래프 추출 → (gleaning) → 그래프 해석 → (claim 추출/해석) → 그래프 분석 → 커뮤니티 탐지 → 인덱싱
 
 - **핵심 기능**: 증분 인덱싱(콘텐츠 해시 델타+병합), 재개 가능 파이프라인(스테이지 체크포인트), S3 캐시 동기화, 병렬 처리
@@ -77,12 +101,48 @@
 
 ### 검색 파이프라인
 
+![검색 파이프라인](./assets/retrieval_pipeline.png)
+
 전략 해석(AUTO 라우팅) → 질의 처리(번역·엔티티/키워드 추출) → 대화 메모리 → 검색(전략별) → 컨텍스트 빌드 → 답변 생성
 
 - **융합/재랭킹**: RRF, 다양성 필터링, Bedrock 리랭킹, 토큰 예산 관리
 - **검색 전략**은 추상 역할(GRAPH/DOCUMENT)로 백엔드를 주입받아 백엔드 무관하게 동작
 
-자세한 컴포넌트·데이터 흐름·알고리즘은 **[기술 문서](./docs/design.ko.md)**를 참고하세요.
+#### 전략별 동작
+
+**GraphRAG (커뮤니티 요약)**
+
+- **simple** — 그래프 순회 없는 OpenSearch 직접 검색(벡터 + 키워드). 가장 빠르며
+  단순 사실 조회에 적합합니다.
+- **local** — 엔티티 중심. 질의 엔티티를 식별해 Neptune 그래프를 순회하여 관련
+  엔티티·관계를 찾고, 커뮤니티 리포트 섹션과 관계 섹션으로 보강한 뒤 벡터/키워드
+  결과와 결합합니다. 특정 엔티티·개념의 상세 분석에 최적입니다.
+- **global** — 커뮤니티 탐지 결과를 활용한 광범위 커버리지. 동적으로 선택된
+  커뮤니티에 map-reduce를 적용해 대규모 정보를 종합합니다. 고수준 통찰과 주제
+  분석에 가장 좋습니다.
+- **drift** — 초기 검색 후 결과를 바탕으로 질의를 반복 정제하며 컨텍스트를
+  확장하고, 수렴 판정으로 무한 루프를 막습니다. 탐색이 필요한 복잡·다면적 질문에
+  탁월합니다.
+- **auto** — 질의 분석으로 위 전략 중 최적을 LLM이 라우팅합니다.
+
+**LightRAG (이중 레벨 키워드)**
+
+- **mix / hybrid** — 고수준·저수준 키워드를 추출(`KeywordsExtractionPrompt`)해
+  관계 벡터 인덱스(고수준) + 엔티티 인덱스(저수준)를 조회하고 Neptune 이웃 확장을
+  수행합니다. `mix`는 여기에 naive 벡터 청크 검색을 추가로 블렌딩합니다. 둘 다
+  동일한 `HybridScorer`(렉시컬 + 시맨틱 + 그래프, RRF + Bedrock 리랭크)를 거칩니다.
+- **naive** — 순수 벡터 청크 검색. LightRAG 베이스라인으로, 빠른 폴백과 비교
+  평가에 유용합니다.
+
+#### 컴포넌트 구성
+
+- **이중 리트리버**: Neptune(관계 순회·엔티티 중심 검색) + OpenSearch(벡터 유사도·BM25 키워드)
+- **융합/랭킹**: RRF로 리트리버 간 점수 결합, 다양성 필터링으로 중복 감소,
+  Bedrock 모델로 컨텍스트 인식 리랭킹, 렉시컬·시맨틱 가중 하이브리드 스코어링
+- **컨텍스트 최적화**: 모델 한도 내 동적 컨텍스트 사이징, 관련성 기반 우선순위
+  선택, 멀티턴 질의를 위한 대화 메모리 통합과 엔티티 추적
+
+자세한 컴포넌트·데이터 흐름·알고리즘은 [**기술 문서**](./docs/design.ko.md)를 참고하세요.
 
 ---
 
@@ -161,6 +221,27 @@ cdk deploy --all
 cdk-nag 검증, 스택 기동 후 Step Functions로 인제스천 실행을 시작하는 방법까지 모두
 담겨 있습니다.
 
+### 환경 변수 설정
+
+OpenSearch 클러스터가 IAM 대신 username/password 인증을 사용한다면 `.env` 파일을
+만드세요.
+
+```bash
+cp .env-template .env
+```
+
+그리고 `.env`에 OpenSearch 자격증명을 입력합니다.
+
+```bash
+# OpenSearch 인증 (config.yaml에서 use_iam이 false인 경우에만 필요)
+OPENSEARCH_USERNAME=your_opensearch_username
+OPENSEARCH_PASSWORD=your_opensearch_password
+```
+
+**참고**: `.env` 파일은 `config.yaml`의 OpenSearch 설정에서 `use_iam: false`인
+경우에만 필요합니다. IAM 인증(`use_iam: true`)을 쓴다면 이 단계는 건너뛰어도
+됩니다.
+
 ---
 
 ## 📖 사용법
@@ -188,7 +269,7 @@ run-prompt-tuning --source-directory ./source --output tuned_prompts.yaml --conf
 
 **전략 선택** — GraphRAG: `simple`(직접 벡터/렉시컬), `local`(엔티티 중심), `global`(커뮤니티 요약, map-reduce), `drift`(점진 탐색), `auto`(LLM 라우터). LightRAG: `mix` / `hybrid` / `naive`(이중 레벨 키워드).
 
-설정·CLI 플래그·Python API·증분 인덱싱은 **[사용자 가이드](./docs/user-guide.ko.md)**, 아키텍처·알고리즘은 **[설계 문서](./docs/design.ko.md)**를 참고하세요.
+설정·CLI 플래그·Python API·증분 인덱싱은 [**사용자 가이드**](./docs/user-guide.ko.md), 아키텍처·알고리즘은 [**설계 문서**](./docs/design.ko.md)를 참고하세요.
 
 ---
 
@@ -203,7 +284,8 @@ uv run mypy unified_kg_rag
 
 - `aws` 마커는 실제 AWS 서비스가 필요한 테스트를 분리하며 CI에서 제외됩니다.
 - DynamoDB/S3는 `moto`, Neptune/OpenSearch는 포트 기반 in-memory fake로 테스트합니다.
-- CI(`.github/workflows/`): ruff/black/isort/mypy + pytest+coverage 게이트, ASH 보안 스캔.
+- CI(`.github/workflows/`): ruff/black/isort/mypy + pytest+coverage 게이트, 그리고
+  비차단(non-blocking) ASH 보안 스캔.
 
 ---
 
@@ -241,3 +323,8 @@ Apache-2.0. [`LICENSE`](./LICENSE) 참고.
 라이브러리 기능 개발과 검증에 크게 기여해 주신 **강지현**님, 그리고 출시 전
 꼼꼼한 리뷰와 실제 코퍼스 테스트를 진행해 주신 **Yusuke Tanimiya**님께
 감사드립니다. 두 분의 기여로 프레임워크가 한층 견고해졌습니다.
+
+## 🏢 소개
+
+AWS가 awslabs 조직에서 유지관리합니다. Apache-2.0 라이선스로 배포됩니다.
+기여를 환영합니다 — [`CONTRIBUTING.md`](./CONTRIBUTING.md)를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10--3.12-blue.svg)](https://www.python.org/downloads/)
 
-🤝 **[Contributing](./CONTRIBUTING.md)**
+🇰🇷 **[한국어 README](./README.ko.md)** · 🤝 **[Contributing](./CONTRIBUTING.md)**
 
 <p align="center">
   <img src="./assets/profile.png" alt="Unified Knowledge Graph RAG on AWS" width="320">
@@ -23,7 +23,7 @@ It reimplements two retrieval methodologies — Microsoft's GraphRAG ("From Loca
 ## 📋 Table of Contents
 
 - [✨ Features & Advantages](#-features--advantages)
-- [🏛️ Architecture Overview](#️-architecture-overview)
+- [🏛️ Architecture Overview](#-architecture-overview)
 - [🚀 Installation](#-installation)
 - [📖 Usage](#-usage)
 - [🧪 Testing & Quality](#-testing--quality)
@@ -65,13 +65,16 @@ caching, multilingual, and hybrid-scoring stack — only the retrieval algorithm
   each document, so re-runs re-index only new/changed documents and merge into the
   live graph (idempotent upserts)
 - **Deletion lineage**: removing a document deletes only its *exclusive* artifacts
+  (entities shared with surviving documents are preserved)
 
 ### 🎯 **Comprehensive Evaluation Framework**
-- **LangChain-based Evaluation**: RAG performance measurement through built-in evaluators
+- **LangChain-based Evaluation**: `correctness` and `partial_correctness` via built-in evaluators
 - **RAGAS Metrics**: answer correctness, answer relevancy, faithfulness, context precision, and context recall
 - **Graph-aware Evaluation**: entity/relationship coverage (recall of expected
   graph artifacts surfaced in the answer) against ground-truth expectations
-  (deterministic, LLM-free, word-boundary matching)
+  (deterministic, LLM-free, word-boundary matching). Precision/F1 are
+  intentionally not emitted — a free-text answer cannot be enumerated into a
+  closed set of entities, so a false-positive count would be meaningless.
 
 ### 🔧 **User Support**
 - **Domain-specific Prompts**: customizable per-prompt overrides via config
@@ -360,6 +363,10 @@ without your own additional security testing, threat modeling, and hardening.**
 ## 🤝 Contributing
 
 We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details.
+
+For extension recipes (adding a search strategy, storage backend, evaluator, or
+renderer), see [CONTRIBUTING.md](CONTRIBUTING.md) and [CLAUDE.md](CLAUDE.md) —
+most extensions are a registry registration and need no dispatch-code edits.
 
 ## 📄 License
 

--- a/docs/design.ko.md
+++ b/docs/design.ko.md
@@ -1,6 +1,8 @@
 # Unified Knowledge Graph RAG on AWS — 기술 문서
 
-본 문서는 `unified-kg-rag-on-aws` 라이브러리의 아키텍처·알고리즘·데이터 모델·운영 측면을 다루는 **기여자/고급 사용자용 설계 레퍼런스**입니다. "무엇/왜"와 빠른 시작은 [README.ko.md](../README.ko.md)를, "어떻게 쓰는가"는 [docs/user-guide.ko.md](user-guide.ko.md)를, 기여/확장 규약은 [CLAUDE.md](../CLAUDE.md)를 참고하세요. 본 문서의 영문판은 [docs/design.md](design.md)에 있습니다.
+> 🇬🇧 English version: [docs/design.md](./design.md)
+
+본 문서는 `unified-kg-rag-on-aws` 라이브러리의 아키텍처·알고리즘·데이터 모델·운영 측면을 다루는 **기여자/고급 사용자용 설계 레퍼런스**입니다. "무엇/왜"와 빠른 시작은 [README.ko.md](../README.ko.md)를, "어떻게 쓰는가"는 [docs/user-guide.ko.md](user-guide.ko.md)를, 기여/확장 규약은 [CLAUDE.md](../CLAUDE.md)를 참고하세요.
 
 ## 목차
 
@@ -127,10 +129,13 @@ class LocalSearchStrategy(BaseSearchStrategy): ...
 > 쓰기(인덱싱) 경로 주석: 레지스트리는 **읽기/평가/렌더/파싱** 경로에 적용됩니다.
 > 쓰기 경로의 `IndexingManager`는 의도적으로 **Neptune + OpenSearch 두 백엔드를
 > 고정**으로 구성합니다(레지스트리 순회가 아님) — 이 두 스토어(그래프 DB + 벡터/
-> 렉시컬 검색)는 프레임워크의 본질적 구성이라 런타임 교체 대상이 아니기 때문입니다.
+> 렉시컬 검색)는 프레임워크의 본질적 구성이라 런타임 교체 대상이 아니고, 백엔드별
+> fan-out(엔티티를 양쪽 스토어에, 엣지보다 엔티티 먼저, 스토어 간 orphan-edge
+> 캐스케이드)은 임의 디스패치가 아니라 의도된 도메인 지식이기 때문입니다.
 > 따라서 새 검색 전략·평가자·렌더러는 레지스트리 등록만으로 추가되지만, 쓰기측
-> 스토어 백엔드 교체는 `GraphIndexer`/`VectorIndexer` 포트 구현 + `IndexingManager`
-> 수정을 수반합니다. (읽기 경로는 `RetrieverRole`→builder 맵으로 이미 일반화됨.)
+> 스토어 백엔드 교체는 `GraphIndexer`/`VectorIndexer` 포트를 구현해 주입하는
+> 방식입니다(`IndexingManager(vector_indexer=…, graph_indexer=…)` — 매니저 코드
+> 수정은 불필요). (읽기 경로는 `RetrieverRole`→builder 맵으로 이미 일반화됨.)
 
 ### 2.4 의존성 규칙 검증 상태
 
@@ -222,21 +227,21 @@ grep으로 검증: `domain/`은 런타임에 `adapters`/`application`을 import�
 ### 6.1 GraphRAG 방법론 (`adapters/search_strategies/`)
 
 - **simple**: OpenSearch 전용 벡터/렉시컬, 그래프 없음. claim 추출이 켜져 있으면 claims 인덱스도 자동 sweep 대상이고, 꺼져 있으면 `_apply_claim_gate`가 claims 인덱스를 명시적으로 제외해 claims-off 실행이 그 인덱스를 절대 조회하지 않습니다.
-- **local**: 엔티티 중심 — 후보 엔티티 → Neptune 그래프 확장 → 빈도 필터 → 텍스트 단위 결합. claim 추출이 켜져 있으면 MS GraphRAG처럼 **claims(covariate)를 컨텍스트에 주입**합니다(`_retrieve_claims`가 claims 인덱스를 별도 조회해 `all_results["claims"]`로 추가, `SectionType.CLAIM` 우선순위로 토큰 예산에 편입). claims-off 기본 경로는 추가 조회를 일절 하지 않습니다.
+- **local**: 엔티티 중심 — 후보 엔티티 → Neptune 그래프 확장 → 빈도 필터 → 텍스트 단위 결합에, **커뮤니티 리포트 섹션**과 **관계 섹션**을 덧붙여 보강합니다(MS GraphRAG local search가 엔티티 + 그 커뮤니티 리포트 + 네트워크 내 관계 + 텍스트 단위를 조립하는 것과 동일). `_retrieve_community_reports`·`_retrieve_relationships`가 엔티티 포커스로 해당 인덱스를 조회하며(없으면 원본 질의로 폴백), 관계 섹션은 `build_relationship_vector_index`로 게이팅되어 관계 벡터 인덱스를 만들지 않는 GraphRAG 전용 배포는 관계 조회를 아예 하지 않습니다. claim 추출이 켜져 있으면 MS GraphRAG처럼 **claims(covariate)를 컨텍스트에 주입**합니다(`_retrieve_claims`가 claims 인덱스를 별도 조회해 `all_results["claims"]`로 추가, `SectionType.CLAIM` 우선순위로 토큰 예산에 편입). claims-off 기본 경로는 추가 조회를 일절 하지 않습니다.
 - **global**: 커뮤니티 리포트 검색 → 커뮤니티 노드 확장 → LLM 동적 관련성 선택 → **map-reduce 합성**(아래 §6.1.1).
 - **drift**: 반복적 질의 진화(커뮤니티 시드 → LLM 질의 재정의/키워드 확장 → 수렴 판정). 선택적으로(`search.drift_search.enable_primer`, 기본 off) MS GraphRAG의 **primer → follow-up** 플로우로 동작합니다 — HyDE primer가 시드 커뮤니티 리포트로부터 가상 답변을 작성하고 질의를 `primer_follow_ups`개의 구체적 하위 질의로 분해해, 하나의 질의를 계속 변형하는 대신 각 하위 질의를 개별 검색 이터레이션으로 실행합니다(`_primer_search`/`_run_primer`). primer가 follow-up을 내지 못하면 반복 루프로 폴백합니다.
 - **auto**: `StrategySelectionPrompt`로 위 전략 중 LLM 라우팅.
 
 #### 6.1.1 Global search map-reduce (`global_search.py`)
 
-`enable_map_reduce`이고 결과가 `map_reduce_min_results` 이상일 때, MS GraphRAG의 정식 map-reduce를 따릅니다(이전의 단순 concat-reduce를 대체).
+`enable_map_reduce`이고 결과가 `map_reduce_min_results` 이상일 때 MS GraphRAG의 정식 map-reduce를 따릅니다. `map_reduce_min_results` 미달이면 검색 결과가 **그대로 통과**하고 합성 단계를 아예 거치지 않습니다 — 커뮤니티 리포트가 몇 개뿐이면 map-reduce로 요약할 필요가 없기 때문입니다.
 
 1. **MAP** — 커뮤니티 리포트를 `map_batch_size`개씩 배치로 묶어, 각 배치마다 `GlobalMapPrompt`로 LLM에게 핵심 포인트(key point)를 추출하고 질의 관련성을 **0-100**으로 채점시킵니다. 배치는 `BatchProcessor`로 동시 실행되며 항목별 graceful fallback이 있습니다.
 2. **FILTER+RANK** — `map_relevance_threshold` 이하 포인트를 버리고 점수 내림차순 정렬(`_filter_and_rank_points`).
 3. **PACK** — `max_map_reduce_tokens` 토큰 예산까지 상위 포인트를 팩(`token_manager.count_tokens` 기준, `_pack_points_within_budget`).
 4. **REDUCE** — 팩된 포인트(relevance 주석 포함)를 `MapReduceSummaryPrompt`로 최종 답변 합성(`_reduce_from_points`). 결과는 `synthesized_summary` `RetrievalResult`로 결과 앞에 추가.
 
-견고성: map 응답이 코드펜스/산문에 싸여 와도 `_parse_map_points`가 JSON을 추출하고, 단일 배치 파싱 실패는 무시합니다. map 단계가 유용한 포인트를 전혀 못 내거나 임계값에 전부 걸러지면 레거시 `_concat_reduce`로 graceful degrade해 global search가 hard-fail하지 않습니다.
+견고성: map 응답이 코드펜스/산문에 싸여 와도 `_parse_map_points`가 JSON을 추출하고, 단일 배치 파싱 실패는 무시합니다. `_concat_reduce`는 두 가지 특정 실패에 대한 degrade 경로입니다 — map 단계가 유용한 포인트를 전혀 못 낸 경우(모든 배치 파싱 실패), 또는 임계값에 포인트가 전부 걸러진 경우 — 덕분에 global search가 hard-fail하지 않고 답변을 합성합니다. 임계값 미달 경로와는 무관합니다.
 
 ### 6.2 LightRAG 방법론 (`lightrag_search.py`)
 
@@ -264,7 +269,7 @@ grep으로 검증: `domain/`은 런타임에 `adapters`/`application`을 import�
 ## 7. 하이브리드 스코어링과 토큰 관리
 
 - **HybridScorer** (`adapters/retrieval/hybrid_scorer.py`): 소스별 결과를 RRF(`rrf_k`) 또는 가중 융합, 다양성 필터링(`diversity_lambda`), Bedrock 리랭킹으로 결합. 가중치·방법은 `config.search.fusion`/`hybrid`. 리랭킹은 `search.reranking.enabled`일 때만 활성화되며, `compress_documents`로 `top_n`을 문서 수에 맞춰 일시 조정 후 복원합니다. 초기화 실패 시 리랭커는 비활성(`None`)으로 degrade.
-  - **IAM 주의**: Bedrock Rerank는 `bedrock:Rerank` 권한을 **`Resource:*`**로 요구합니다(실 AWS E2E에서 발견 — 모델 ARN로 좁히면 AccessDenied). IaC에 전용 statement로 분리합니다.
+  - **IAM 주의**: Bedrock Rerank는 `bedrock:Rerank` 권한을 `Resource:*`로 요구합니다(실 AWS E2E에서 발견 — 모델 ARN으로 좁히면 AccessDenied). IaC에 전용 statement로 분리합니다.
 - **TokenManager** (`adapters/retrieval/token_manager.py`): 모델 한도 내 컨텍스트 최적화. 섹션 타입별 우선순위 배수로 가중(`PRIORITY_MULTIPLIERS`: TEXT 1.3 / ENTITY 1.2 / RELATIONSHIP 1.1 / CLAIM 1.1 / COMMUNITY 1.0 / GENERAL 0.8), 우선순위 내림차순으로 예산 내 섹션을 선택. `SectionType.CLAIM`은 query-time claims 주입(§6.1)을 토큰 예산에 편입하기 위한 타입입니다.
 - **토큰 카운팅** (`adapters/aws/token_counter.py`): Bedrock `count_tokens` API가 단일 진실 소스. 실패 시에만 공백 단어 수로 degrade(서드파티 토크나이저 미사용). 절단은 char 비율로 후보를 잡고 API로 검증하는 수렴 루프.
 
@@ -377,18 +382,30 @@ CLI: `run-eval --eval-data-path <json> [--search-strategy ...]`.
 
 모든 외부 서비스 의존성은 포트 뒤에 있고, 오케스트레이터가 그 포트를 **생성자
 주입**으로 받습니다 — 따라서 non-AWS/커스텀 백엔드를 서브클래싱이나 디스패치 코드
-수정 없이 끼울 수 있습니다.
+수정 없이 끼울 수 있습니다. 포트와 각각의 기본
+(Bedrock/Neptune/OpenSearch/DynamoDB) 어댑터는 다음과 같습니다.
 
-| 포트 | 기본 어댑터 | 주입 방법 |
-|---|---|---|
-| `LLMFactoryPort` / `EmbeddingFactoryPort` (`Protocol`) | Bedrock 팩토리 | `GraphRAGChain(model_factory=...)`; `OpenSearchIndexer(embedding_factory=...)`; `OpenSearchRetriever(embedding_factory=...)` |
-| `VectorIndexer` / `GraphIndexer` (ABC) | OpenSearch / Neptune | `IndexingManager(vector_indexer=..., graph_indexer=...)` |
-| 리트리버(role-keyed builder) | OpenSearch / Neptune 리트리버 | `GraphRAGChain(retriever_builders={RetrieverRole.GRAPH: lambda: MyRetriever(...)})` |
-| `DocStatusPort` / `CachePort` (`Protocol`) | DynamoDB / 파일시스템 | 구조적 적합(structural) — 메서드 형태만 맞추면 됨 |
+| 포트 | 계약 | 기본 어댑터 | 주입 방법 |
+|---|---|---|---|
+| `LLMFactoryPort` / `EmbeddingFactoryPort` (`ports/model_factory.py`, `Protocol`) | LangChain 호환 모델을 반환하는 `get_model()` / `get_model_info()` | `BedrockLanguageModelFactory` / `BedrockEmbeddingModelFactory` | `GraphRAGChain(model_factory=...)`; `OpenSearchIndexer(embedding_factory=...)`; `OpenSearchRetriever(embedding_factory=...)` |
+| `VectorIndexer` / `GraphIndexer` (`ports/indexer.py`, ABC) | `index_*` / `upsert_*` / `delete_by_id` | `OpenSearchIndexer` / `NeptuneIndexer` | `IndexingManager(vector_indexer=..., graph_indexer=...)` |
+| 리트리버(role-keyed builder) | `BaseGraphRAGRetriever.aretrieve` | `OpenSearchRetriever` / `NeptuneRetriever` | `GraphRAGChain(retriever_builders={RetrieverRole.GRAPH: lambda: MyGraphRetriever(...)})` |
+| `DocStatusPort` (`ports/doc_status.py`, `Protocol`) | `get` / `put` / `list_all` / `diff` | `DynamoDBDocStatusStore` | 파이프라인이 스토어를 받음; 구조적으로 적합하면 됨 |
+| `CachePort` (`ports/cache.py`, `Protocol`) | 파이프라인 상태 get/set | 파일시스템 `CacheManager` | 구조적 적합 — 기본적으로 AWS 불필요 |
 
 model-factory·doc-status·cache 포트는 `runtime_checkable Protocol`이라, 커스텀
-클래스는 **메서드 형태만** 맞으면 되고 상속할 베이스 클래스가 없습니다. `tests/
-fixtures/fakes/`의 인메모리 fake(`FakeGraphStore`/`FakeVectorStore`)가 인덱서
+클래스는 **메서드 형태만** 맞으면 되고 상속할 베이스 클래스가 없습니다. 예시(로컬
+LLM 제공자):
+
+```python
+class OllamaModelFactory:                 # 구조적으로 LLMFactoryPort
+    def get_model(self, model_id, **kwargs): ...   # LangChain 모델 반환
+    def get_model_info(self, model_id): ...        # ModelInfo | None 반환
+
+chain = GraphRAGChain(config=cfg, model_factory=OllamaModelFactory())
+```
+
+`tests/fixtures/fakes/`의 인메모리 fake(`FakeGraphStore`/`FakeVectorStore`)가 인덱서
 포트의 동작하는 참조 구현이며 — 전체 인제스천+인덱싱 파이프라인이 AWS 없이 이들로
 돌아갑니다. 커스텀 스토어의 출발점으로 권장합니다. 이 프레임워크는 AWS 어댑터만
 제공하고, 커뮤니티/로컬 어댑터(NetworkX 그래프, 로컬 벡터DB, Ollama 등)는 이

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,5 +1,7 @@
 # Unified Knowledge Graph RAG on AWS — Technical Documentation
 
+> 🇰🇷 한국어판: [docs/design.ko.md](./design.ko.md)
+
 This document is a **design reference for contributors and advanced users**, covering the architecture, algorithms, data model, and operational aspects of the `unified-kg-rag-on-aws` library. For the "what/why" and a quick start, see [README.md](../README.md); for "how to use it," see the [User Guide](user-guide.md); for contribution/extension conventions, see [CLAUDE.md](../CLAUDE.md).
 
 ## Table of Contents
@@ -125,6 +127,18 @@ class LocalSearchStrategy(BaseSearchStrategy): ...
 
 This pattern follows the same philosophy as the existing `ParserFactory._loader_configs` (declarative parser registration).
 
+> Write-path note: the registries cover the **read / evaluation / render / parse**
+> paths. On the write path, `IndexingManager` deliberately composes **two fixed
+> backends** (Neptune + OpenSearch) rather than iterating a registry — those two
+> stores (graph DB + vector/lexical search) are constitutive of the framework,
+> not runtime-swappable choices, and the per-backend fan-out (entities to both
+> stores, entities-before-edges phasing, the orphan-edge cascade) is deliberate
+> domain knowledge rather than arbitrary dispatch. So a new search strategy,
+> evaluator, or renderer is added by registration alone, while replacing a
+> write-side store means implementing the `GraphIndexer` / `VectorIndexer` port
+> and injecting it (`IndexingManager(vector_indexer=…, graph_indexer=…)`). The
+> read path is already generalized through the `RetrieverRole` → builder map.
+
 ### 2.4 Dependency Rule Verification Status
 
 Verified with grep: `domain/` does not import `adapters`/`application` at runtime, and neither does `ports/`. One compile-time-only exception remains — `domain/retrieval/strategy_registry.py` references `adapters.retrieval.base.BaseSearchStrategy` under `TYPE_CHECKING` (because the registry stores strategy subclasses). Extracting pure strategy/retriever ports would also remove this type-level reference; it is left in place as a deliberate boundary (see "Deliberate Design Boundaries" at the end of this document).
@@ -222,14 +236,14 @@ The `GraphRAGChain` (an LCEL Runnable) in `application/retrieval/rag_chain.py` p
 
 #### 6.1.1 Global search map-reduce (`global_search.py`)
 
-When `enable_map_reduce` is set and results are at least `map_reduce_min_results`, it follows MS GraphRAG's canonical map-reduce; otherwise it returns a direct concat-reduce.
+When `enable_map_reduce` is set and results are at least `map_reduce_min_results`, it follows MS GraphRAG's canonical map-reduce. Below `map_reduce_min_results` the retrieved results **pass through unchanged** — no synthesis stage runs at all, because a handful of community reports do not need a map-reduce to be summarized.
 
 1. **MAP** — Community reports are batched in groups of `map_batch_size`, and for each batch `GlobalMapPrompt` asks the LLM to extract key points and score query relevance from **0-100**. Batches are run concurrently via `BatchProcessor`, with per-item graceful fallback.
 2. **FILTER+RANK** — Drops points at or below `map_relevance_threshold` and sorts by score in descending order (`_filter_and_rank_points`).
 3. **PACK** — Packs the top points up to the `max_map_reduce_tokens` token budget (based on `token_manager.count_tokens`, `_pack_points_within_budget`).
 4. **REDUCE** — Synthesizes the final answer from the packed points (with relevance annotations) via `MapReduceSummaryPrompt` (`_reduce_from_points`). The result is prepended to the results as a `synthesized_summary` `RetrievalResult`.
 
-Robustness: Even if the map response comes wrapped in code fences or prose, `_parse_map_points` extracts the JSON, and a single batch's parse failure is ignored. If the map stage produces no useful points at all or everything is filtered out by the threshold, it gracefully degrades to the legacy `_concat_reduce` so global search does not hard-fail.
+Robustness: Even if the map response comes wrapped in code fences or prose, `_parse_map_points` extracts the JSON, and a single batch's parse failure is ignored. `_concat_reduce` is the degradation path for two specific failures — the map stage yielding no usable points at all (every batch failed to parse), or the threshold filtering out every point — so global search still synthesizes an answer instead of hard-failing. It is not the below-threshold path.
 
 ### 6.2 LightRAG Methodology (`lightrag_search.py`)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,5 +1,7 @@
 # Unified Knowledge Graph RAG on AWS — User Guide
 
+> 🇰🇷 한국어판: [docs/user-guide.ko.md](./user-guide.ko.md)
+
 This is the practical, how-to-use guide for **unified-kg-rag-on-aws** — an AWS-native
 knowledge-graph RAG framework that builds knowledge graphs from large,
 multilingual document corpora and answers questions over them. It reimplements


### PR DESCRIPTION
## Why

Reported symptom: the Korean README rendered stray `**` in places (e.g. **기술 문서**), and its content had drifted a long way from the English one.

Investigating that turned up two documented behaviours that contradict the code, so this PR covers both the formatting bug and the accuracy fixes.

## The rendering bug

Three bold spans closed directly against a Hangul particle after a `)` or a backtick:

```
input:   **[기술 문서](./docs/design.ko.md)**를
renders: **<a href="...">기술 문서</a>**를        ← literal ** leaks
```

CommonMark only lets a right-flanking `**` close when the preceding character is not punctuation, *or* the following one is whitespace/punctuation. A Hangul particle is neither, so the span never closes. English is unaffected because a space always follows — this failure mode is specific to CJK text.

| File | Line | Pattern |
|---|---|---|
| `README.ko.md` | 85 | `**[기술 문서](…)**를` |
| `README.ko.md` | 191 | `**[사용자 가이드](…)**,` + `**[설계 문서](…)**를` |
| `docs/design.ko.md` | 267 | ``**`Resource:*`**로`` |

Verified by rendering all eight Markdown files through a CommonMark parser: zero literal `**` remain outside code spans.

## Statements that contradicted the code

- **`design.md` / `design.ko.md` §6.1.1** — both said that below `map_reduce_min_results` global search "returns a direct concat-reduce". `global_search.py:445` returns the results **unchanged**; `_concat_reduce` is reached only when the map phase yields no parsable points (`:461`) or the threshold filters every point out (`:471`). Corrected in both languages.
- **`design.ko.md` §2.3** — said replacing a write-side store entails *modifying* `IndexingManager`. Its constructor already accepts `vector_indexer` / `graph_indexer` and only builds the concrete adapters when neither is supplied. Rewritten as port injection.

## Broken anchor

`README.md:26` carried the 🏛️ heading's variation selector (U+FE0F) into the fragment (`#️-architecture-overview`), so the ToC link never resolved. GitHub's anchor is `#-architecture-overview`.

## Translation parity

Drift ran in **both** directions, so this reconciles both.

Added to the Korean docs:
- `README.ko.md`: license/Python badges, a table of contents, **both pipeline diagrams** (already in `assets/`, previously only referenced by the English README), the highlights block, per-strategy detail and component architecture, the `.env` configuration section, an About section, and the note that the ASH scan is non-blocking (confirmed: `continue-on-error: true`)
- `design.ko.md`: the ports table's `Contract` column (restored from 3 columns to 4, and `DocStatusPort`/`CachePort` split back apart), the `OllamaModelFactory` example (the only code block missing from the translation), and `local` strategy's community-report/relationship sections plus the `build_relationship_vector_index` gate

Added to the English docs:
- `design.md` §2.3: the write-path note explaining why `IndexingManager` composes two fixed backends instead of iterating a registry — matching the manager's own docstring
- `README.md`: the rationale for not emitting precision/F1 from `graph_aware`, the concrete LangChain metric names, the deletion-lineage clarification, and the extension-recipe pointer
- A Korean-counterpart link in each of the three English docs; previously none had one (`grep -c 'ko\.md'` was 0 across all three), so English readers had no way to discover the translations

`user-guide.md` / `user-guide.ko.md` were already in good shape — tables 85/85, code fences 52/52, `###` headings 36/36 — and only needed the language link.

## Verification

- All six docs' anchors resolve (checked against GitHub's anchor algorithm); all 12 Korean ToC/internal fragments resolve
- Every relative link target and image path exists
- No literal `**` in rendered output for any of the eight Markdown files
- `pre-commit` passes (Python hooks correctly skip — docs-only change)
- Customer-data grep over the diff is clean

## Not in scope

Fully converging the two READMEs' prose is larger and different in character; left for a follow-up. Sections where the Korean text is roughly half the English length (`design` §1, §2.0) were compared line by line and left alone — that is language density, not lost content.